### PR TITLE
fixing verb

### DIFF
--- a/episodes/05-objectives.md
+++ b/episodes/05-objectives.md
@@ -29,7 +29,7 @@ or because they are interesting to you from a theoretical perspective.
 
 The desired end point (the objective) of a lesson should be new things that the learner can do.
 Cognitive skills cannot be equally easily acquired:
-we can attain the abilty to remember and distinguish between new concepts more quickly than,
+we can attain the ability to remember and distinguish between new concepts more quickly than,
 and must do so before,
 we can begin applying those concepts or creating something new based on them.
 

--- a/episodes/05-objectives.md
+++ b/episodes/05-objectives.md
@@ -29,9 +29,9 @@ or because they are interesting to you from a theoretical perspective.
 
 The desired end point (the objective) of a lesson should be new things that the learner can do.
 Cognitive skills cannot be equally easily acquired:
-we can attain the ability to remember and distinguish between new concepts more quickly than,
-and must do so before,
-we can begin applying those concepts or creating something new based on them.
+before we can apply concepts and create something new, we must attain the ability to remember 
+and distinguish between new concepts. 
+Remembering and distinguishing are also abilities that are often faster to gain then applying or creating.
 
 We must try to be realistic about how far along this scale we can move learners during a single workshop/lesson.
 This is one reason why the target audience is so important:

--- a/episodes/05-objectives.md
+++ b/episodes/05-objectives.md
@@ -29,7 +29,7 @@ or because they are interesting to you from a theoretical perspective.
 
 The desired end point (the objective) of a lesson should be new things that the learner can do.
 Cognitive skills cannot be equally easily acquired:
-we can attain the abilty to remember and distinguishing between new concepts more quickly than,
+we can attain the abilty to remember and distinguish between new concepts more quickly than,
 and must do so before,
 we can begin applying those concepts or creating something new based on them.
 


### PR DESCRIPTION
This PR matches the verbs.

I found this sentence a little hard to read.  Specifically I found optional phrase "and must do so before"  difficult to follow the sentence. After rereading it a couple of times without the phrase it made sense but wondering if we can move that phrase to make it easier to read?  Maybe to another sentence following?  

My best effort at rearranging but could still use some work.
> Before we can apply concepts and create something new, we must attain the ability to remember and distinguish between new concepts.  Remembering and distinguishing is also a task that is often faster to obtain then applying or creating.
