### PR TITLE
Adding pilot timeanddate links

### DIFF
--- a/learners/pilot-description.md
+++ b/learners/pilot-description.md
@@ -38,7 +38,7 @@ or another training covering similar topics, e.g. an RStudio Instructor.
 
 This training will take place virtually, combining video and screen sharing on Zoom
 with a collaborative notetaking document for sharing notes, responses to exercises, and links to further resources.
-The first pilot will take place 22-25 March 2022 (13:00-17:00 UTC) and 10&11 May 2022 (12:00-16:00 UTC).
+The first pilot will take place 22-25 March 2022 ([13:00-17:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Collaborative+Lesson+Development+Training+Pilot+1&iso=20220322T13&p1=1440&ah=4)) and 10&11 May 2022 ([12:00-16:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Collaborative+Lesson+Development+Training+Pilot+1%2C+pt2+&iso=20220510T12&p1=%3A&ah=4)).
 
 There is no fee to join the pilot, but spaces are limited.
 To apply to participate in the training, please fill out this short form: https://forms.gle/9ZXZEjgJGWNQmxY47


### PR DESCRIPTION
Adding the time and date links for the first time day of each session.  Lead me to realize I should warn people that the follow-up sessions are an hour earlier.
Sarah