### PR TITLE
update setup instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,8 +2,6 @@
 title: Setup
 ---
 
-TODO link to the `sandpaper-docs` setup page
-
-For setup instructions, visit the [sandpaper documentation
-site](https://carpentries.github.io/sandpaper-docs/setup.html).
+Before joining this training,
+participants should have a [GitHub](https://github.com) account.
 


### PR DESCRIPTION
We are not expecting to ask trainees to clone a local repository and work there during this training, so we don't need to point them towards the `sandpaper` documentation.

If someone can give this a (very quick) review, that would be great. I only want to make sure I haven't forgotten something.