### PR TITLE
renaming bullet and adding virtual example

### DIFF
--- a/episodes/11-formative-assessment.md
+++ b/episodes/11-formative-assessment.md
@@ -63,7 +63,7 @@ Any instructional tool that generates feedback and is used in a formative way to
 
 - **reflection** at the end of a session to help process learning - e.g. asking learners to write down things they learned, things they want to know more about and any questions they still have
 - **concept maps and diagrams** - asking learners to reflect by drawing/labeling a concept map/diagram or writing down a list of new concepts and skills they’ve learned and (optionally) how they relate to one another or connect with previous knowledge
-- **minute cards** - gauging learners’ satisfaction and understanding using agreed signals (e.g. raising different coloured post-it/sticky notes to indicate that the pace is too fast/slow, that they completed/have not completed an exercise).
+- **checking in** - gauging learners’ satisfaction and understanding using agreed signals (e.g. raising different coloured post-it/sticky notes or zoom reactions to indicate that the pace is too fast/slow, that they completed/have not completed an exercise).
 
 Many other formative assessment tools can be found in Briggs’ list of ["21 ways to check for student understanding"](https://www.opencolleges.edu.au/informed/features/21-ways-to-check-for-student-understanding/) or Edutopia's ["56 Examples of Formative Assessment"](https://www.edutopia.org/groups/assessment/250941).
 

--- a/episodes/11-formative-assessment.md
+++ b/episodes/11-formative-assessment.md
@@ -63,7 +63,7 @@ Any instructional tool that generates feedback and is used in a formative way to
 
 - **reflection** at the end of a session to help process learning - e.g. asking learners to write down things they learned, things they want to know more about and any questions they still have
 - **concept maps and diagrams** - asking learners to reflect by drawing/labeling a concept map/diagram or writing down a list of new concepts and skills they’ve learned and (optionally) how they relate to one another or connect with previous knowledge
-- **checking in** - gauging learners’ satisfaction and understanding using agreed signals (e.g. raising different coloured post-it/sticky notes or zoom reactions to indicate that the pace is too fast/slow, that they completed/have not completed an exercise).
+- **checking in** - gauging learners’ satisfaction and understanding using agreed signals (e.g. raising different coloured post-it/sticky notes or [Zoom reactions](https://coderefinery.github.io/manuals/zoom-mechanics/#reactions) to indicate that the pace is too fast/slow, that they completed/have not completed an exercise).
 
 Many other formative assessment tools can be found in Briggs’ list of ["21 ways to check for student understanding"](https://www.opencolleges.edu.au/informed/features/21-ways-to-check-for-student-understanding/) or Edutopia's ["56 Examples of Formative Assessment"](https://www.edutopia.org/groups/assessment/250941).
 


### PR DESCRIPTION
My understanding of minute cards is that they are the break time feedback that takes about a minute to complete.  In the Carpentries in-person workshops, we often use sticky notes for this purpose and then add an additional use for stickies by using them to get immediate feedback on pacing, learners needing help, and the speed of the workshop.  In my mind at least, that secondary use is separate and isn't the "minute card" purpose, because it has nothing to do with a minute, so I changed this bullet point name.  I'm not fully happy with the "checking in" name for this bullet point, might be a little informal.  Would appreciate other suggestions, or an argument for calling this point "minute cards" still.  Maybe "immediate feedback"?

Either way, I think we should still add the virtual example of zoom reactions