### PR TITLE
add callout about managing GH notifications

### DIFF
--- a/episodes/24-collaborating.md
+++ b/episodes/24-collaborating.md
@@ -218,7 +218,15 @@ the Reviewer should follow all the steps but close the PR at the end instead of 
 Having an open, publicly-visible list of all the issues with your project is a helpful way of letting people know you are aware of issues and you are working on them. This can indicate to an external audience that the project is active.
 It also provides you and your collaborators with an "at a glance" view of the state of the project, making it easier to prioritise future work.
 
-As we have seen in the previous episode, GitHub's notifications framework **Mentions** plays an important part in communicating between collaborators and is used as a way of alerting team members of activities and referencing one issue/comment/pull requests from another.
+GitHub provides a useful notification feature for collaborative work - _mentions_. 
+The mention system notifies team members when somebody else references them 
+in an issue, comment or pull request - 
+you can use this to notify people when you want to check a detail with them, 
+or let them know something has been fixed or changed 
+(much easier than writing out all the same information again in an email!). 
+You can use the mention system to link to individual GitHub accounts 
+or whole teams for mentioning multiple people. 
+Typing `@` in GitHub will bring up a list of all accounts and teams linked to the repository that can be "mentioned".
 
 [Slack](https://slack.com/) is commonly used in the Carpentries community for quick, day-to-day message exchange among teams. You can create your own [Slack workspace for free](https://slack.com/intl/en-gb/) or create a channel for your lesson development project under [the Carpentries public Slack workspace](https://swcarpentry.slack.com/). Note that the Carpentries Slack is an enterprise workspace so all messages and files will be retained and no messages will be lost (for free workspaces only the most recent 10,000 messages can be viewed and searched and file storage limit is 5 GB).
 

--- a/episodes/26-external.md
+++ b/episodes/26-external.md
@@ -106,6 +106,21 @@ GitHub implements a comprehensive [notifications system](https://docs.github.com
 
 Check out [GitHub's documentation on setting notifications on individual repository](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository). You can choose whether to watch or unwatch an individual repository, or can choose to only be notified of certain event types such as issues, pull requests, mentions, etc.
 
+:::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
+
+## Time management tip: share the next callout, do not teach it
+
+The next callout contains a lot of information,
+and can require a lot of time to discuss fully while training.
+We recommend that you do not dwell on these details while teaching
+unless you have time to spare.
+
+Instead, you could share [a link to the callout](#managing-github-notifications) 
+and mention to trainees that this information can be helpful 
+if they are struggling with GitHub notifications.
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::::::::::::::::::::::::::::: callout
 
 ## Managing GitHub Notifications

--- a/episodes/26-external.md
+++ b/episodes/26-external.md
@@ -102,10 +102,68 @@ You can encourage contributions to your lesson from newcomers by using specific 
 
 ### Noticing When Something Happens
 
-GitHub implements a comprehensive [notifications system](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications) to keep you up-to-date with activities in the lesson repository. GitHub also provides an additional useful notification feature for collaborative work - **Mentions**. The mention system notifies team members when somebody else references them in an issue, comment or pull request - you can use this to notify people when you want to check a detail with them, or let them know something has been fixed or changed (much easier than writing out all the same information again in an email!). You can use the mention system to link to individual GitHub accounts or whole teams for mentioning multiple people. Typing `@` in GitHub will bring up a list of all accounts and teams linked to the repository that can be "mentioned".
+GitHub implements a comprehensive [notifications system](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications) to keep you up-to-date with activities in the lesson repository. 
 
 Check out [GitHub's documentation on setting notifications on individual repository](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository). You can choose whether to watch or unwatch an individual repository, or can choose to only be notified of certain event types such as issues, pull requests, mentions, etc.
 
+:::::::::::::::::::::::::::::::::::::::::: callout
+
+## Managing GitHub Notifications
+
+If you work on multiple projects,
+or the projects you follow on GitHub are particularly active,
+the volume of notifications you receive can quickly become overwhelming.
+Here are some approaches you can take to help you stay on top of things, 
+and distinguish the high-priority tasks and important updates
+from the regular traffic.
+
+### Email Notifications
+
+If you want to filter, organise, and redirect email notifications from GitHub,
+here are some characteristics of the messages that you make use of:
+
+- All GitHub notifications are sent from the address `notifications@github.com`.
+- Notification emails are sent to the address `repo-name@noreply.github.com`, 
+  where `repo-name` is the name of the repository where the notification was triggered.
+- The email subject begins with `[org-or-user/repo-name]`,
+  where `org-or-user` is the name of the organisation or the username of the user who owns the repository
+  and `repo-name` is the name of the repository where the notification was triggered.
+- In addition to your email address, 
+  the cc field of the message contains an address that describes
+  the type of event that triggered the notification,
+  e.g. `author@noreply.github.com` for activity on an issue or pull request that you opened,
+  `mention@noreply.github.com` for a mention of your username, 
+  or `team-mention@noreply.github.com` for a mention of a team you are a member of,
+  etc.
+
+Most email clients provide configuration for rules that can be set to
+redirect messages to particular folders, and/or to annotate them with a mark or flag,
+based on this kind of information. 
+[Here is the documentation for setting such rules in Gmail](https://support.google.com/mail/answer/6579?hl=en).
+
+### Notifications on GitHub.com
+
+The alternative to using email to keep track of project activity is
+to manage notifications on GitHub.
+Adjust how you receive notifications in [the _Notifications_ section of your account settings](https://github.com/settings/notifications).
+When logged in, you can visit <https://github.com/notifications> to see notifications for your account,
+presented as a table.
+Through this interface, you can:
+
+- group notifications by repository.
+- see notifications for a particular repository.
+- see particular types of notification e.g. mentions, issue assignments, etc.
+- create more sophisticated filters using the search bar, 
+  e.g. all mentions for all repositories in a particular organisation.
+
+The account notification settings allow you to specify 
+certain types of notification that should be sent by email, 
+while everything else is collected in the web interface.
+Whatever strategy you choose, one of the most important habits that will help you
+stay on top of your projects and tasks is 
+to remember to check these notifications frequently.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ### Saying "No"
 

--- a/episodes/26-external.md
+++ b/episodes/26-external.md
@@ -135,6 +135,11 @@ here are some characteristics of the messages that you make use of:
   `mention@noreply.github.com` for a mention of your username, 
   or `team-mention@noreply.github.com` for a mention of a team you are a member of,
   etc.
+- The email header (metadata) includes a `mailing-list` field with an identifier in the form
+  `repo-name.org-or-user.github.com`,
+  which can be used to filter by the project and/or its owner.
+
+[GitHub provides detailed documentation about all of the properties you can use to filter their notification emails](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#filtering-email-notifications).
 
 Most email clients provide configuration for rules that can be set to
 redirect messages to particular folders, and/or to annotate them with a mark or flag,


### PR DESCRIPTION
If merged, this will close #24

This feels like a long callout to put into the episode, but it is certainly useful information for developers. Perhaps I should add a Trainer Note above it, reminding Trainers not to go through this information in detail unless they find themselves with time to spare? Or would we be better off leaving it out altogether and perhaps adding this content elsewhere e.g. in the community handbook? And/or as a post on The Carpentries blog?