### PR TITLE
Add more context for objectives and episodes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,6 +50,7 @@ episodes:
 - short-break1.md
 - objectives.md
 - long-break1.md
+- episodes.md
 - infrastructure.md
 - short-break2.md
 - episode-objectives.md

--- a/episodes/episode-objectives.md
+++ b/episodes/episode-objectives.md
@@ -36,6 +36,19 @@ Defining these objectives _before writing the episode content_ helps us to:
   (we will discuss this more in the next two episodes)
 - summarise the skills the learner can expect to gain by following this section of the lesson
 
+As before, here are some recommendations to help you define these episode-level objectives:
+
+- Aim for 2-4 objectives per episode. 
+  If you need to write more than that,
+  consider breaking this section down into multiple episodes.
+- To ensure your episode content aligns with the overall goals for the lesson,
+  try to identify which lesson-level objective(s) your episode
+  will contribute to.
+- In the context of the previous recommendation,
+  consider how the objectives for your episode fit as a
+  component of the higher-level skills/understanding defined
+  in the lesson-level objective(s).
+
 ::: challenge
 
 ### Exercise: define objectives for your episode (30 minutes)

--- a/episodes/episodes.md
+++ b/episodes/episodes.md
@@ -24,7 +24,7 @@ self-contained units (with their own narrative arc)
 that nevertheless contribute to the larger whole
 (the theme or story that runs through a full season).
 It also helps to think about the typical length of an episode:
-these chunks should not take more than an hour to finish.
+these chunks contain 20-60 minutes of content (teaching + exercises).
 
 Each episode will exist as a page in the website we will build for our lessons.
 

--- a/episodes/episodes.md
+++ b/episodes/episodes.md
@@ -1,0 +1,58 @@
+---
+title: Episodes
+teaching: 5
+exercises: 25
+---
+
+At the end of the previous section,
+you defined the learning objectives for your lesson as a whole.
+
+Rather than write the lesson as a single, long document,
+we recommend that you break it up into chunks
+like chapters in a book or episodes in a season of a TV series.
+This can help manage learners' cognitive load by 
+ensuring that you organise content into coherent, more self-contained chunks,
+and makes it easier for instructors to schedule regular and frequent breaks while teaching.
+Thinking about how content can be broken down like this
+early in the lesson design process
+helps you to consider the path learners will take to reach your defined objectives,
+and identify the component skills and knowledge they will need to pick up on the way.
+
+In The Carpentries, we refer to these individual parts of a lesson as _episodes_,
+to encourage lesson developers to think about them as 
+self-contained units (with their own narrative arc) 
+that nevertheless contribute to the larger whole
+(the theme or story that runs through a full season).
+It also helps to think about the typical length of an episode:
+these chunks should not take more than an hour to finish.
+
+Each episode will exist as a page in the website we will build for our lessons.
+
+## Planning Your Episodes
+
+Before we can start creating the episodes of a lesson,
+we need to spend some time planning out the number and order of them.
+The learning objectives you defined for your lesson can help with this:
+at the very least, it is probably a good idea to have one episode dedicated to each objective.
+You might also find that you can "decompose" the lesson-level objectives 
+into more finely-grained steps that learners can take towards those end points:
+
+- What new knowledge and skills will learners need to acquire to be ready to fulfil the overall objectives for your lesson?
+- What order should these concepts and skills be introduced in? Are some dependent on others?
+- If some of these concepts and skills are complex, can they be broken down even further?
+
+:::::::::::::::::::::::::::::::::::::::: challenge
+
+## Exercise: Defining Episodes for a Lesson (25 minutes)
+
+1. Based on the lesson-level objectives and your knowledge of the lesson topic,
+   divide the lesson up into logical blocks, that should each take no more than 60 minutes to teach.
+2. Next, assign responsibility for one of these episodes to each collaborator in your team.
+   They will focus on this episode for the rest of this training, 
+   and you will teach these episodes in a trial run between parts 1 and 2 of this training.
+   
+If the length of the list of episodes you create exceeds the number of collaborators you have on your team,
+do not assign more than one episode to each team member for now, but
+**we strongly recommend that you assign yourselves consecutive episodes at the beginning of your lesson**.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/episodes.md
+++ b/episodes/episodes.md
@@ -57,14 +57,18 @@ Some questions you might ask yourself to help break down your lesson-level learn
 ## Exercise: Defining Episodes for a Lesson (25 minutes)
 
 With your team, 
+
 1. Based on the lesson-level objectives and your knowledge of the lesson topic,
-   divide the lesson up into logical blocks, that should each take no more than 60 minutes to teach.
+   divide the lesson up into logical blocks, that should each take approximately 20-60 minutes to teach.
 2. Next, assign responsibility for one of these episodes to each collaborator in your team.
    They will focus on this episode for the rest of this training, 
    and you will teach these episodes in a trial run between parts 1 and 2 of this training.
-   
-If the length of the list of episodes you create exceeds the number of collaborators you have on your team,
-do not assign more than one episode to each team member for now, but
+
+If the length of the list of episodes you create is smaller than the number of collaborators you have on your team,
+try assigning two people to a single episode, 
+with each taking responsibility for a subset of the objectives defined for that episode.
+If you plan more episodes than you have people in your team,
+do not assign more than one episode to each collaborator for now, but
 **we strongly recommend that you assign yourselves consecutive episodes at the beginning of your lesson**.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/episodes.md
+++ b/episodes/episodes.md
@@ -35,7 +35,18 @@ we need to spend some time planning out the number and order of them.
 The learning objectives you defined for your lesson can help with this:
 at the very least, it is probably a good idea to have one episode dedicated to each objective.
 You might also find that you can "decompose" the lesson-level objectives 
-into more finely-grained steps that learners can take towards those end points:
+into more finely-grained steps that learners can take towards those end points.
+For example, the lesson level objective
+
+- _"create formatted page content with Markdown"_ 
+
+may be broken down into, 
+
+- _"create bold, italic, and linked text with Markdown"_
+- _"explain the different header levels in Markdown"_
+- _"add images with a caption and alternative text description to a Markdown document"_
+
+Some questions you might ask yourself to help break down your lesson-level learning objectives include:
 
 - What new knowledge and skills will learners need to acquire to be ready to fulfil the overall objectives for your lesson?
 - What order should these concepts and skills be introduced in? Are some dependent on others?

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -295,14 +295,6 @@ the individual chunks or sections that the lesson is separated into.
 The episode pages of the lesson site will be constructed from Markdown files
 in the `episodes` folder of the lesson repository.
 
-::: callout
-
-### Why episodes?
-
-TODO: add context and explanation for our use of "episodes" to describe chunks of a lesson.
-
-:::
-
 The `episodes` folder of the new repository contains a single file,
 `introduction.md`.
 The content of this file includes examples of how to write Markdown files

--- a/episodes/objectives.md
+++ b/episodes/objectives.md
@@ -134,6 +134,14 @@ SMART objectives should be:
 - **R**elevant: they should be relevant to the overall topic or domain of the lesson as a whole.
 - **T**ime-bound: they should include some timeframe within which the goal will be reached. For learning objectives, this is built into the approach described above.
 
+Note that, for any lesson/curriculum that will be taught in a fixed amount of time,
+_attainable_ and _time-bound_ are overlapping:
+learning objectives for your lesson will answer the question
+"What will learners be able to do by the end of this lesson?"
+and the time available to teach the lesson, 
+combined with the expected prior knowledge of your target audience, 
+will determine how attainable they are.
+
 
 :::::: instructor
 
@@ -248,6 +256,18 @@ We have discussed the importance of defining objectives early in
 the lesson design process,
 and looked at some examples of objectives written for other lessons.
 Now it is time to begin defining objectives for your own.
+
+Here are some recommendations to help you get started:
+
+- Aim for 3-4 objectives for every 6 hours your lesson will take to teach.
+  (For example, this curriculum is designed to be taught in ~18 hours
+  and has [ten learning objectives](index.md#learning-objectives).)
+- These objectives are for your lesson as a whole: 
+  try to define the "end point" knowledge and skills you want learners to acquire.
+  You can think of these as the things you would test in a fictional "final exam"
+  your learners would be able to tackle.
+- Later you will write "episode-level" objectives that should define
+  intermediate steps towards the high-level objectives you identify for your lesson here.
 
 ::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION
Fixes #71 
Fixes #73 
Fixes #76 

This adds some more context and guidance to help trainees write objectives. 

It also (more importantly?) _adds a new episode_ (😱) about episodes,
addressing the problem identified in #73 where we had forgotten to get them to do this.
I think this only reflects what we did anyway in the pilots, so doesn't add teaching time in real terms,
but I acknowledge this may feel scary and would appreciate feedback! 😅 