### PR TITLE
Add trainer notes recommending use of lesson design notes template

### DIFF
--- a/episodes/audience.md
+++ b/episodes/audience.md
@@ -100,6 +100,19 @@ _you are not your learners_:
 they will arrive at the lesson with different priorities,
 interests, and challenges than your own.
 
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
+
+## Lesson Design Notes Document
+
+At this point, it may be helpful to share 
+[the template for a Lesson Design Notes document][design-notes-template]
+with trainees.
+They can make a copy of this document and fill in the lesson title now,
+then populate the document with the notes 
+and information they produce throughout the training.
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
 ::::::::::::::::::::::::::::::::::::::  challenge
 
 ## Exercise: thinking about target audience (15 minutes total for both parts)

--- a/episodes/wrap-up2.md
+++ b/episodes/wrap-up2.md
@@ -52,6 +52,7 @@ Take some time to provide this feedback, before moving onto the second part of t
 
 :::::::::::::
 
+
 ::: challenge
 
 ## Organise Your Knowledge (10-15 min)
@@ -71,6 +72,39 @@ If you do not know where to start, consider the following list for a starting po
 :::::::::::::
 
 Please stay in touch as you plan for your trial run.
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
+
+## Adding Design Notes to the Lesson Site
+
+If trainees would like to add the Design Notes document
+they have been working on to their lesson site,
+they can do the following:
+
+1. replace the first 13 lines with
+
+  ```
+  ---
+  title: Lesson Design Notes
+  ---
+  ```
+2. save the file to the `instructors/` directory
+3. add the filename below `instructors:` in `config.yml` as they have done 
+   [for episode filenames below `episodes:` previously](./infrastructure.html#adding-a-new-episode-to-the-lesson-navigation).
+   For example, if their file is saved with the name 'design-notes.md':
+
+  ```yaml
+  # Information for Instructors
+  instructors:
+  - design-notes.md
+  ```
+
+This will make the page accessible from the 'More' dropdown in Instructor View.
+
+_Note that concept maps with GraphViz are not currently supported by the lesson infrastructure,
+so any concept maps added to the document on CodiMD will not be displayed correctly on the lesson site._
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/wrap-up2.md
+++ b/episodes/wrap-up2.md
@@ -88,7 +88,8 @@ they can do the following:
   title: Lesson Design Notes
   ---
   ```
-2. save the file to the `instructors/` directory
+2. save the file to the `instructors/` directory, and any images used in the file to the `episodes/fig` directory
+   (the paths to source files for images will need to be adjusted to begin `episodes/fig/`)
 3. add the filename below `instructors:` in `config.yml` as they have done 
    [for episode filenames below `episodes:` previously](./infrastructure.html#adding-a-new-episode-to-the-lesson-navigation).
    For example, if their file is saved with the name 'design-notes.md':

--- a/links.md
+++ b/links.md
@@ -5,6 +5,7 @@
 [codimd-notes-template]: https://codimd.carpentries.org/cldt-notes-template?both#Exercise-evaluating-learning-objectives-15-minutes
 [component-guide]: https://carpentries.github.io/sandpaper-docs/component-guide.html
 [dc]: https://datacarpentry.org/
+[design-notes-template]: https://codimd.carpentries.org/HPwUE3FnTeSQJ9-_5EfU7Q?view#
 [f1000-course-design-guide]: https://f1000research.com/documents/9-1377
 [github]: https://github.com/
 [glosario]: https://glosario.carpentries.org/


### PR DESCRIPTION
Fixes #72 by adding guidance for Trainers at the start of the curriculum, recommending the use of [the Lesson Design Notes template](https://codimd.carpentries.org/HPwUE3FnTeSQJ9-_5EfU7Q?edit) by trainees throughout. I added a second note at the very end of part 2, with guidance Trainers can share with trainees if they want to include their design notes in their lesson site.

I can imagine a greater integration of the design notes document into the training, but that would be a much bigger PR (mentioning it in a lot of exercises, for example) and I think we should wait to see how well this works in the training before writing it into the curriculum.