### PR TITLE
Provide more context for steps in the lesson design process

### DIFF
--- a/episodes/fig/cldt-design-process.svg
+++ b/episodes/fig/cldt-design-process.svg
@@ -33,7 +33,8 @@
      inkscape:window-x="0"
      inkscape:window-y="25"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg1151" />
+     inkscape:current-layer="svg1151"
+     inkscape:document-rotation="0" />
   <defs
      id="defs1095">
     <marker
@@ -141,12 +142,12 @@
        id="path1107" />
   </g>
   <rect
-     x="93.249"
+     x="93.249001"
      y="11.774"
-     width="118.7"
+     width="122.81701"
      height="36.409"
      fill="#ffd6d8"
-     stroke="#000"
+     stroke="#000000"
      stroke-linejoin="round"
      stroke-width="1.058"
      id="rect1111"

--- a/episodes/fig/cldt-step-1.svg
+++ b/episodes/fig/cldt-step-1.svg
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   version="1.1"
+   viewBox="0 0 297 210"
+   id="svg1151"
+   sodipodi:docname="cldt-step-1.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1470"
+     inkscape:window-height="891"
+     id="namedview1153"
+     showgrid="false"
+     inkscape:zoom="0.5"
+     inkscape:cx="176.25984"
+     inkscape:cy="396.85039"
+     inkscape:window-x="572"
+     inkscape:window-y="1477"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1151"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs1095">
+    <marker
+       id="Arrow2Mend"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(.6) rotate(180) translate(0)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1080" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1083" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-9"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1086" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-7"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1089" />
+    </marker>
+    <marker
+       id="Arrow2Mend-6"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1092" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata1097">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 38.506,86.081 C 46.3346,65.667 60.176,49.257 90.082,34.969"
+     marker-end="url(#Arrow2Mend-6)"
+     id="path1099"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 203.25,31.295 c 24.518,7.7012 44.967,20.42 60.319,49.114"
+     marker-end="url(#Arrow2Mend)"
+     id="path1101"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="M 74.21,157.45 C 73.64962,163.3727 49.226,145.459 39.272,123.845"
+     marker-end="url(#Arrow2Mend-8-7)"
+     id="path1103"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 164.26083,179.55 c 0.56038,2.7543 -18.09437,2.2728 -27.93074,1.0951"
+     marker-end="url(#Arrow2Mend-8-9)"
+     id="path1105"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 263.37,119.11 c 4.3403,0.56038 -8.7876,24.984 -24.626,34.938"
+     marker-end="url(#Arrow2Mend-8)"
+     id="path1107"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <rect
+     x="93.249001"
+     y="11.774"
+     width="121.875"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1111"
+     style="fill:#e6f1ff;fill-opacity:1;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="98.04866"
+     y="25.818758"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25"
+     xml:space="preserve"
+     id="text1117"><tspan
+       sodipodi:role="line"
+       id="tspan1761"
+       x="98.04866"
+       y="25.818758"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'"><tspan
+         x="98.04866"
+         y="25.818758"
+         id="tspan1113"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'">1. Define desired</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1763"
+       x="98.04866"
+       y="39.930008"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'">    learning outcomes</tspan></text>
+  <rect
+     x="159.76"
+     y="84.13"
+     width="130.26"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1119"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="164.66527"
+     y="98.174248"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25"
+     xml:space="preserve"
+     id="text1125"><tspan
+       sodipodi:role="line"
+       id="tspan1766"
+       x="164.66527"
+       y="98.174248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish"><tspan
+         x="164.66527"
+         y="98.174248"
+         id="tspan1121"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">2. Design assessments</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1768"
+       x="164.66527"
+       y="112.2855"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">     for these outcomes</tspan></text>
+  <rect
+     x="162.6"
+     y="156.49"
+     width="107.03"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1127"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="167.27422"
+     y="171.7489"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width=".26458"
+     style="line-height:1.25;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1133"><tspan
+       x="167.27422"
+       y="171.7489"
+       id="tspan1129"
+       style="-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">3. Develop</tspan><tspan
+       x="167.27422"
+       y="185.86003"
+       id="tspan1131"
+       style="-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">    relevant content</tspan></text>
+  <rect
+     x="24.375"
+     y="156.49001"
+     width="109.55903"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1135"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="31.12291"
+     y="170.39427"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1141"><tspan
+       x="31.12291"
+       y="170.39427"
+       id="tspan1137"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">4. Assess</tspan><tspan
+       x="31.12291"
+       y="184.5054"
+       id="tspan1139"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    learner progress</tspan></text>
+  <rect
+     x="13.254"
+     y="84.129997"
+     width="78.383171"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1143"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="19.900017"
+     y="99.393448"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1149"><tspan
+       x="19.900017"
+       y="99.393448"
+       id="tspan1145"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">5. Evaluate</tspan><tspan
+       x="19.900017"
+       y="113.50457"
+       id="tspan1147"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    curriculum</tspan></text>
+</svg>

--- a/episodes/fig/cldt-step-2.svg
+++ b/episodes/fig/cldt-step-2.svg
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   version="1.1"
+   viewBox="0 0 297 210"
+   id="svg1151"
+   sodipodi:docname="cldt-step-2.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1470"
+     inkscape:window-height="891"
+     id="namedview1153"
+     showgrid="false"
+     inkscape:zoom="1.073342"
+     inkscape:cx="456.6157"
+     inkscape:cy="389.96447"
+     inkscape:window-x="572"
+     inkscape:window-y="1477"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1151"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs1095">
+    <marker
+       id="Arrow2Mend"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(.6) rotate(180) translate(0)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1080" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1083" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-9"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1086" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-7"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1089" />
+    </marker>
+    <marker
+       id="Arrow2Mend-6"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1092" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata1097">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 38.506,86.081 C 46.3346,65.667 60.176,49.257 90.082,34.969"
+     marker-end="url(#Arrow2Mend-6)"
+     id="path1099"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 203.25,31.295 c 24.518,7.7012 44.967,20.42 60.319,49.114"
+     marker-end="url(#Arrow2Mend)"
+     id="path1101"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="M 74.21,157.45 C 73.64962,163.3727 49.226,145.459 39.272,123.845"
+     marker-end="url(#Arrow2Mend-8-7)"
+     id="path1103"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 164.26087,179.55 c 0.55856,2.7543 -18.03553,2.2728 -27.8399,1.0951"
+     marker-end="url(#Arrow2Mend-8-9)"
+     id="path1105"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 263.37,119.11 c 4.3403,0.56038 -8.7876,24.984 -24.626,34.938"
+     marker-end="url(#Arrow2Mend-8)"
+     id="path1107"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <rect
+     x="93.249001"
+     y="11.774"
+     width="121.875"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1111"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="98.04866"
+     y="25.818758"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1117"><tspan
+       sodipodi:role="line"
+       id="tspan1761"
+       x="98.04866"
+       y="25.818758"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;"><tspan
+         x="98.04866"
+         y="25.818758"
+         id="tspan1113"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">1. Define desired</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1763"
+       x="98.04866"
+       y="39.930008"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">    learning outcomes</tspan></text>
+  <rect
+     x="159.76"
+     y="84.13"
+     width="130.26"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1119"
+     style="fill:#e6f1ff;fill-opacity:1;stroke-width:2.00000001;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="164.66527"
+     y="98.174248"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25"
+     xml:space="preserve"
+     id="text1125"><tspan
+       sodipodi:role="line"
+       id="tspan1766"
+       x="164.66527"
+       y="98.174248"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'"><tspan
+         x="164.66527"
+         y="98.174248"
+         id="tspan1121"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'">2. Design assessments</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1768"
+       x="164.66527"
+       y="112.2855"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'">     for these outcomes</tspan></text>
+  <rect
+     x="162.6"
+     y="156.49"
+     width="107.03"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1127"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="167.27422"
+     y="171.7489"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width=".26458"
+     style="line-height:1.25;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1133"><tspan
+       x="167.27422"
+       y="171.7489"
+       id="tspan1129"
+       style="-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">3. Develop</tspan><tspan
+       x="167.27422"
+       y="185.86003"
+       id="tspan1131"
+       style="-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">    relevant content</tspan></text>
+  <rect
+     x="24.375"
+     y="156.49001"
+     width="109.55903"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1135"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="31.12291"
+     y="170.39427"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1141"><tspan
+       x="31.12291"
+       y="170.39427"
+       id="tspan1137"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">4. Assess</tspan><tspan
+       x="31.12291"
+       y="184.5054"
+       id="tspan1139"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    learner progress</tspan></text>
+  <rect
+     x="13.254"
+     y="84.129997"
+     width="78.383171"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1143"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="19.900017"
+     y="99.393448"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1149"><tspan
+       x="19.900017"
+       y="99.393448"
+       id="tspan1145"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">5. Evaluate</tspan><tspan
+       x="19.900017"
+       y="113.50457"
+       id="tspan1147"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    curriculum</tspan></text>
+</svg>

--- a/episodes/fig/cldt-step-3.svg
+++ b/episodes/fig/cldt-step-3.svg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   version="1.1"
+   viewBox="0 0 297 210"
+   id="svg1151"
+   sodipodi:docname="cldt-step-3.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1470"
+     inkscape:window-height="891"
+     id="namedview1153"
+     showgrid="false"
+     inkscape:zoom="1.073342"
+     inkscape:cx="463.13738"
+     inkscape:cy="648.03692"
+     inkscape:window-x="572"
+     inkscape:window-y="1477"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1151"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs1095">
+    <marker
+       id="Arrow2Mend"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(.6) rotate(180) translate(0)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1080" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1083" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-9"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1086" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-7"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1089" />
+    </marker>
+    <marker
+       id="Arrow2Mend-6"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1092" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata1097">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 38.506,86.081 C 46.3346,65.667 60.176,49.257 90.082,34.969"
+     marker-end="url(#Arrow2Mend-6)"
+     id="path1099"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 203.25,31.295 c 24.518,7.7012 44.967,20.42 60.319,49.114"
+     marker-end="url(#Arrow2Mend)"
+     id="path1101"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="M 74.21,157.45 C 73.64962,163.3727 49.226,145.459 39.272,123.845"
+     marker-end="url(#Arrow2Mend-8-7)"
+     id="path1103"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 164.26097,179.55 c 0.55415,2.7543 -17.89315,2.2728 -27.62012,1.0951"
+     marker-end="url(#Arrow2Mend-8-9)"
+     id="path1105"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 263.37,119.11 c 4.3403,0.56038 -8.7876,24.984 -24.626,34.938"
+     marker-end="url(#Arrow2Mend-8)"
+     id="path1107"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <rect
+     x="93.249001"
+     y="11.774"
+     width="121.875"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1111"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="98.04866"
+     y="25.818758"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1117"><tspan
+       sodipodi:role="line"
+       id="tspan1761"
+       x="98.04866"
+       y="25.818758"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;"><tspan
+         x="98.04866"
+         y="25.818758"
+         id="tspan1113"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">1. Define desired</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1763"
+       x="98.04866"
+       y="39.930008"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">    learning outcomes</tspan></text>
+  <rect
+     x="159.76"
+     y="84.13"
+     width="130.26"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1119"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="164.66527"
+     y="98.174248"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1125"><tspan
+       sodipodi:role="line"
+       id="tspan1766"
+       x="164.66527"
+       y="98.174248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;"><tspan
+         x="164.66527"
+         y="98.174248"
+         id="tspan1121"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">2. Design assessments</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1768"
+       x="164.66527"
+       y="112.2855"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">     for these outcomes</tspan></text>
+  <rect
+     x="162.6"
+     y="156.49"
+     width="107.03"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1127"
+     style="fill:#e6f1ff;fill-opacity:1;stroke-width:2.00000001;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold';stroke-width:0.264583"
+     x="167.15634"
+     y="171.81345"
+     id="text1783"><tspan
+       sodipodi:role="line"
+       id="tspan1781"
+       x="167.15634"
+       y="171.81345"
+       style="font-size:11.2889px;stroke-width:0.264583">3. Develop</tspan><tspan
+       sodipodi:role="line"
+       x="167.15634"
+       y="185.92458"
+       style="font-size:11.2889px;stroke-width:0.264583"
+       id="tspan1785">    relevant content</tspan></text>
+  <rect
+     x="24.375"
+     y="156.49001"
+     width="109.55903"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1135"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="31.12291"
+     y="170.39427"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1141"><tspan
+       x="31.12291"
+       y="170.39427"
+       id="tspan1137"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">4. Assess</tspan><tspan
+       x="31.12291"
+       y="184.5054"
+       id="tspan1139"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    learner progress</tspan></text>
+  <rect
+     x="13.254"
+     y="84.129997"
+     width="78.383171"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1143"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="19.900017"
+     y="99.393448"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1149"><tspan
+       x="19.900017"
+       y="99.393448"
+       id="tspan1145"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">5. Evaluate</tspan><tspan
+       x="19.900017"
+       y="113.50457"
+       id="tspan1147"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    curriculum</tspan></text>
+</svg>

--- a/episodes/fig/cldt-step-4.svg
+++ b/episodes/fig/cldt-step-4.svg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   version="1.1"
+   viewBox="0 0 297 210"
+   id="svg1151"
+   sodipodi:docname="cldt-step-4.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1147"
+     id="namedview1153"
+     showgrid="false"
+     inkscape:zoom="1.073342"
+     inkscape:cx="288.44935"
+     inkscape:cy="311.70423"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1151"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs1095">
+    <marker
+       id="Arrow2Mend"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(.6) rotate(180) translate(0)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1080" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1083" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-9"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1086" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-7"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1089" />
+    </marker>
+    <marker
+       id="Arrow2Mend-6"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1092" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata1097">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 38.506,86.081 C 46.3346,65.667 60.176,49.257 90.082,34.969"
+     marker-end="url(#Arrow2Mend-6)"
+     id="path1099"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 203.25,31.295 c 24.518,7.7012 44.967,20.42 60.319,49.114"
+     marker-end="url(#Arrow2Mend)"
+     id="path1101"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="M 74.21,157.45 C 73.64962,163.3727 49.226,145.459 39.272,123.845"
+     marker-end="url(#Arrow2Mend-8-7)"
+     id="path1103"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 164.26068,179.55 c 0.56737,2.7543 -18.3203,2.2728 -28.27948,1.0951"
+     marker-end="url(#Arrow2Mend-8-9)"
+     id="path1105"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 263.37,119.11 c 4.3403,0.56038 -8.7876,24.984 -24.626,34.938"
+     marker-end="url(#Arrow2Mend-8)"
+     id="path1107"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <rect
+     x="93.249001"
+     y="11.774"
+     width="121.875"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1111"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="98.04866"
+     y="25.818758"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1117"><tspan
+       sodipodi:role="line"
+       id="tspan1761"
+       x="98.04866"
+       y="25.818758"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;"><tspan
+         x="98.04866"
+         y="25.818758"
+         id="tspan1113"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">1. Define desired</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1763"
+       x="98.04866"
+       y="39.930008"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">    learning outcomes</tspan></text>
+  <rect
+     x="159.76"
+     y="84.13"
+     width="130.26"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1119"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="164.66527"
+     y="98.174248"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1125"><tspan
+       sodipodi:role="line"
+       id="tspan1766"
+       x="164.66527"
+       y="98.174248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish"><tspan
+         x="164.66527"
+         y="98.174248"
+         id="tspan1121"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">2. Design assessments</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1768"
+       x="164.66527"
+       y="112.2855"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">     for these outcomes</tspan></text>
+  <rect
+     x="162.6"
+     y="156.49"
+     width="107.03"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1127"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     xml:space="preserve"
+     style="font-weight:normal;font-size:11.28889999999999993px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish;stroke-width:0.264583;font-style:normal;font-stretch:normal;font-variant:normal;"
+     x="167.15634"
+     y="171.81345"
+     id="text1783"><tspan
+       sodipodi:role="line"
+       id="tspan1781"
+       x="167.15634"
+       y="171.81345"
+       style="font-size:11.28889999999999993px;stroke-width:0.264583;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">3. Develop</tspan><tspan
+       sodipodi:role="line"
+       x="167.15634"
+       y="185.92458"
+       style="font-size:11.28889999999999993px;stroke-width:0.264583;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+       id="tspan1785">    relevant content</tspan></text>
+  <rect
+     x="24.374998"
+     y="156.49001"
+     width="108.30902"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1135"
+     style="fill:#e6f1ff;fill-opacity:1;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="28.841429"
+     y="170.39427"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width=".26458"
+     style="line-height:1.25;-inkscape-font-specification:'Mulish Bold';font-family:Mulish;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1141"><tspan
+       x="28.841429"
+       y="170.39427"
+       id="tspan1137"
+       style="-inkscape-font-specification:'Mulish Bold';font-family:Mulish;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal;">4. Assess</tspan><tspan
+       x="28.841429"
+       y="184.5054"
+       id="tspan1139"
+       style="-inkscape-font-specification:'Mulish Bold';font-family:Mulish;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal;">    learner progress</tspan></text>
+  <rect
+     x="13.254"
+     y="84.129997"
+     width="78.383171"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1143"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="19.900017"
+     y="99.393448"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1149"><tspan
+       x="19.900017"
+       y="99.393448"
+       id="tspan1145"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">5. Evaluate</tspan><tspan
+       x="19.900017"
+       y="113.50457"
+       id="tspan1147"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    curriculum</tspan></text>
+</svg>

--- a/episodes/fig/cldt-step-5.svg
+++ b/episodes/fig/cldt-step-5.svg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   version="1.1"
+   viewBox="0 0 297 210"
+   id="svg1151"
+   sodipodi:docname="cldt-step-5.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1470"
+     inkscape:window-height="891"
+     id="namedview1153"
+     showgrid="false"
+     inkscape:zoom="1.073342"
+     inkscape:cx="280.06433"
+     inkscape:cy="509.21816"
+     inkscape:window-x="572"
+     inkscape:window-y="1477"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1151"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs1095">
+    <marker
+       id="Arrow2Mend"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(.6) rotate(180) translate(0)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1080" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1083" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-9"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1086" />
+    </marker>
+    <marker
+       id="Arrow2Mend-8-7"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1089" />
+    </marker>
+    <marker
+       id="Arrow2Mend-6"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="scale(-.6)"
+         d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z"
+         fill-rule="evenodd"
+         stroke="#000"
+         stroke-linejoin="round"
+         stroke-width=".625"
+         id="path1092" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata1097">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 38.506,86.081 C 46.3346,65.667 60.176,49.257 90.082,34.969"
+     marker-end="url(#Arrow2Mend-6)"
+     id="path1099"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 203.25,31.295 c 24.518,7.7012 44.967,20.42 60.319,49.114"
+     marker-end="url(#Arrow2Mend)"
+     id="path1101"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="M 74.21,157.45 C 73.64962,163.3727 49.226,145.459 39.272,123.845"
+     marker-end="url(#Arrow2Mend-8-7)"
+     id="path1103"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 164.2605,179.55 c 0.57545,2.7543 -18.58088,2.2728 -28.68172,1.0951"
+     marker-end="url(#Arrow2Mend-8-9)"
+     id="path1105"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <path
+     d="m 263.37,119.11 c 4.3403,0.56038 -8.7876,24.984 -24.626,34.938"
+     marker-end="url(#Arrow2Mend-8)"
+     id="path1107"
+     style="fill:none;stroke:#000000;stroke-width:2.5" />
+  <rect
+     x="93.249001"
+     y="11.774"
+     width="121.875"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1111"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="98.04866"
+     y="25.818758"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="line-height:1.25;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+     xml:space="preserve"
+     id="text1117"><tspan
+       sodipodi:role="line"
+       id="tspan1761"
+       x="98.04866"
+       y="25.818758"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;"><tspan
+         x="98.04866"
+         y="25.818758"
+         id="tspan1113"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">1. Define desired</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1763"
+       x="98.04866"
+       y="39.930008"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish;">    learning outcomes</tspan></text>
+  <rect
+     x="159.76"
+     y="84.13"
+     width="130.26"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1119"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="164.66527"
+     y="98.174248"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1125"><tspan
+       sodipodi:role="line"
+       id="tspan1766"
+       x="164.66527"
+       y="98.174248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish"><tspan
+         x="164.66527"
+         y="98.174248"
+         id="tspan1121"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">2. Design assessments</tspan></tspan><tspan
+       sodipodi:role="line"
+       id="tspan1768"
+       x="164.66527"
+       y="112.2855"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">     for these outcomes</tspan></text>
+  <rect
+     x="162.6"
+     y="156.49"
+     width="107.03"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1127"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     xml:space="preserve"
+     style="font-weight:normal;font-size:11.28889999999999993px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish;stroke-width:0.264583;font-style:normal;font-stretch:normal;font-variant:normal;"
+     x="167.15634"
+     y="171.81345"
+     id="text1783"><tspan
+       sodipodi:role="line"
+       id="tspan1781"
+       x="167.15634"
+       y="171.81345"
+       style="font-size:11.28889999999999993px;stroke-width:0.264583;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">3. Develop</tspan><tspan
+       sodipodi:role="line"
+       x="167.15634"
+       y="185.92458"
+       style="font-size:11.28889999999999993px;stroke-width:0.264583;-inkscape-font-specification:Mulish;font-family:Mulish;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;"
+       id="tspan1785">    relevant content</tspan></text>
+  <rect
+     x="24.375"
+     y="156.49001"
+     width="109.55902"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1135"
+     style="fill:#e8e8e8;fill-opacity:1;stroke-width:0.75;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="31.122906"
+     y="170.39427"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:Mulish"
+     xml:space="preserve"
+     id="text1141"><tspan
+       x="31.122906"
+       y="170.39427"
+       id="tspan1137"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">4. Assess</tspan><tspan
+       x="31.122906"
+       y="184.5054"
+       id="tspan1139"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:Mulish">    learner progress</tspan></text>
+  <rect
+     x="13.254001"
+     y="84.129997"
+     width="77.133041"
+     height="36.409"
+     fill="#ffd6d8"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="1.058"
+     id="rect1143"
+     style="fill:#e6f1ff;fill-opacity:1;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <text
+     x="17.777044"
+     y="99.393448"
+     font-family="Mulish"
+     font-size="11.289px"
+     font-weight="600"
+     stroke-width="0.26458"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'"
+     xml:space="preserve"
+     id="text1149"><tspan
+       x="17.777044"
+       y="99.393448"
+       id="tspan1145"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'">5. Evaluate</tspan><tspan
+       x="17.777044"
+       y="113.50457"
+       id="tspan1147"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Mulish;-inkscape-font-specification:'Mulish Bold'">    curriculum</tspan></text>
+</svg>

--- a/episodes/formative-assessment.md
+++ b/episodes/formative-assessment.md
@@ -22,6 +22,15 @@ After completing this episode, participants should be able to...
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+![
+In the next two episodes, we will design assessments to measure learners' attainment 
+of the objectives we defined previously.
+](./fig/cldt-step-3.svg){
+alt="An overview of the iterative process of lesson design and development, 
+adapted from Nicholl's five phases,
+with step 2, 'Design assessments for these outcomes' highlighted."
+width="67%"
+}
 
 As we have seen previously, defining objectives for a lesson (or a teaching episode) can help to focus your content on the most important learning outcomes and outline the scope of your lesson project. With learning objectives you have defined your **intended (or planned) curriculum** - what you set out to accomplish with your lesson. The skills and knowledge your learners actually leave with and can demonstrate after the workshop having followed the **implemented curriculum** in the classroom is called the **attained curriculum**. **Implemented curriculum** includes the concepts, relationships and skills that are explicitly covered in your lesson and translated into classroom practices - i.e. the teaching and learning activities that should lead to your learners attaining knowledge.
 

--- a/episodes/narrative.md
+++ b/episodes/narrative.md
@@ -23,6 +23,17 @@ After completing this episode, participants should be able to...
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+![
+Now that we have designed assessments to measure attainment of the objectives set for the lesson,
+it is time to begin developing teaching content to give learners the knowledge and skills
+they need to succeed in those assessments.
+](./fig/cldt-step-3.svg){
+alt="An overview of the iterative process of lesson design and development, 
+adapted from Nicholl's five phases,
+with step 3, 'Develop relevant content' highlighted."
+width="67%"
+}
+
 ## Creating a Narrative
 
 <!--- Should this section go before LO and questions? -->

--- a/episodes/objectives.md
+++ b/episodes/objectives.md
@@ -21,6 +21,16 @@ After completing this episode, participants should be able to...
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+![
+In this episode we will begin the first step of our iterative design process:
+defining the skills and knowledge we want learners to leave with.
+](./fig/cldt-step-1.svg){
+alt="An overview of the iterative process of lesson design and development, 
+adapted from Nicholl's five phases,
+with step 1, 'Define desired learning outcomes' highlighted."
+width="67%"
+}
+
 
 At this stage of the training,
 you should have a clear idea of who the target audience is for your lesson,

--- a/episodes/preparing.md
+++ b/episodes/preparing.md
@@ -23,6 +23,18 @@ After completing this episode, participants should be able to...
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+![
+In this episode, we will discuss how you can measure learner progress 
+and gather feedback about the effectiveness of your content
+by teaching the lesson.
+](./fig/cldt-step-4.svg){
+alt="An overview of the iterative process of lesson design and development, 
+adapted from Nicholl's five phases,
+with step 4, 'Assess learner progress' highlighted."
+width="67%"
+}
+
+
 By now you should have developed objectives, exercises/formative assessments,
 and examples for at least one of the episodes in your lesson. In order to prepare to teach it (for the first time in particular) you'll need to create a teaching plan and design a method to collect feedback on your lesson.
 

--- a/episodes/reflecting.md
+++ b/episodes/reflecting.md
@@ -20,9 +20,20 @@ After completing this episode, participants should be able to...
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 Welcome back!
-In this section of the training,
+
+![
+In this episode, we will discuss the final step of the iterative lesson design process:
+how you can use the notes, information, and feedback you collected when trialling your lesson
+to identify ways that the design and content could be improved.
+](./fig/cldt-step-5.svg){
+alt="An overview of the iterative process of lesson design and development, 
+adapted from Nicholl's five phases,
+with step 5, 'Evaluate curriculum' highlighted."
+width="67%"
+}
+
+In part 2 of the training,
 we will learn more about the skills and tools you can use to become
 an effective collaborator on an open source lesson.
 Before moving on to cover that,


### PR DESCRIPTION
Fixes #40 by adding versions of the lesson design process overview diagram at stages through the curriculum, to highlight when we start learning about a new step of the iterative process. This should be particularly useful for "Reflecting on Trial Runs" where trainees will probably need a reminder of what has happened before and why it is important to start thinking about their lesson design again at this stage.
