### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Collaborative Lesson Development Training Curriculum
 
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
 [![Build and Deploy Site](https://github.com/carpentries/lesson-development-training/actions/workflows/sandpaper-main.yaml/badge.svg)](https://github.com/carpentries/lesson-development-training/actions/workflows/sandpaper-main.yaml)
 
 Curriculum for a short (~3 days) workshop teaching skills required for
-collaborative lesson development. The lesson is visible at: https://carpentries.github.io/lesson-development-training/. 
+collaborative lesson development. The lesson is visible at: https://carpentries.github.io/lesson-development-training/.
 
 **This curriculum is currently being piloted.**
 If you are interested in helping us develop this material,
@@ -17,10 +17,10 @@ please [contact Toby Hodges](mailto:tobyhodges@carpentries.org).
 
 Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for contributing guidelines and details on how to get involved with this project.
 
-Also see the current list of [issues](https://github.com/carpentries/lesson-development-training/issues) 
-for ideas for contributing to this training curriculum. Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg). 
+Also see the current list of [issues](https://github.com/carpentries/lesson-development-training/issues)
+for ideas for contributing to this training curriculum. Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg).
 This indicates that the issue does not require in-depth knowledge of the project
-and lesson infrastructure, 
+and lesson infrastructure,
 and is a good opportunity for a new contributor to get involved.
 
 To learn more about how this lesson site is built and how you can edit the pages, see [the Introduction to The Carpentries Workbench][sandpaper-docs].
@@ -39,7 +39,7 @@ Current maintainers of this lesson are:
 
 ## Acknowledgements
 
-The following people aided the development of this curriculum, 
+The following people aided the development of this curriculum,
 by providing suggestions, reviews, and inspiration:
 
 * [Allegra Via](https://github.com/allegravia)

--- a/episodes/collaborating.md
+++ b/episodes/collaborating.md
@@ -218,17 +218,17 @@ the Reviewer should follow all the steps but close the PR at the end instead of 
 Having an open, publicly-visible list of all the issues with your project is a helpful way of letting people know you are aware of issues and you are working on them. This can indicate to an external audience that the project is active.
 It also provides you and your collaborators with an "at a glance" view of the state of the project, making it easier to prioritise future work.
 
-GitHub provides a useful notification feature for collaborative work - _mentions_. 
-The mention system notifies team members when somebody else references them 
-in an issue, comment or pull request - 
-you can use this to notify people when you want to check a detail with them, 
-or let them know something has been fixed or changed 
-(much easier than writing out all the same information again in an email!). 
-You can use the mention system to link to individual GitHub accounts 
-or whole teams for mentioning multiple people. 
+GitHub provides a useful notification feature for collaborative work - _mentions_.
+The mention system notifies team members when somebody else references them
+in an issue, comment or pull request -
+you can use this to notify people when you want to check a detail with them,
+or let them know something has been fixed or changed
+(much easier than writing out all the same information again in an email!).
+You can use the mention system to link to individual GitHub accounts
+or whole teams for mentioning multiple people.
 Typing `@` in GitHub will bring up a list of all accounts and teams linked to the repository that can be "mentioned".
 
-[Slack](https://slack.com/) is commonly used in the Carpentries community for quick, day-to-day message exchange among teams. You can create your own [Slack workspace for free](https://slack.com/intl/en-gb/) or create a channel for your lesson development project under [the Carpentries public Slack workspace](https://swcarpentry.slack.com/). Note that the Carpentries Slack is an enterprise workspace so all messages and files will be retained and no messages will be lost (for free workspaces only the most recent 10,000 messages can be viewed and searched and file storage limit is 5 GB).
+[Slack](https://slack.com/) is commonly used in the Carpentries community for quick, day-to-day message exchange among teams. You can create your own [Slack workspace for free](https://slack.com/intl/en-gb/) or create a channel for your lesson development project under [the Carpentries public Slack workspace](https://carpentries.slack.com/). Note that the Carpentries Slack is an enterprise workspace so all messages and files will be retained and no messages will be lost (for free workspaces only the most recent 10,000 messages can be viewed and searched and file storage limit is 5 GB).
 
 Collaborators can also use other platforms to discuss lesson development or receive contributions from newcomers who are not yet fluent in using GitHub's systems of communication. The Carpentries can assist with creating a mailing list specific to the development of your lesson on their [TopicBox](https://carpentries.topicbox.com/) platform for managing threaded email discussions. Also make sure to join the [Incubator lesson developers mailing list](https://carpentries.topicbox.com/groups/incubator-developers) on TopicBox to keep an eye on announcements and discussions relating to lesson development in general within the Carpentries community.
 

--- a/episodes/operations.md
+++ b/episodes/operations.md
@@ -158,7 +158,7 @@ and to learn from the experience of others.
 
 Here are a community activities and channels that you might be interested in joining:
 
-- The `lesson-dev` channel on [The Carpentries Slack workspace](https://swc-slack-invite.herokuapp.com/). This is a platform for the community to ask questions and make announcements about lesson development. You could also browse the other channels on the workspace for any that are relevant to the topic of your lesson.
+- The `lesson-dev` channel on [The Carpentries Slack workspace](https://slack-invite.carpentries.org/). This is a platform for the community to ask questions and make announcements about lesson development. You could also browse the other channels on the workspace for any that are relevant to the topic of your lesson.
   - You may also find it helpful to create a new channel on Slack for discussion of your lesson. Chat channels like this can be valuable ways for a remote team to communicate and collaborate.
 - [The `incubator-developers` list on TopicBox](https://carpentries.topicbox.com/groups/incubator-developers). The Carpentries Curriculum Team uses this mailing list to make relevant announcements to the community of lesson developers working in Incubator.
 - The Carpentries Curriculum Team hosts monthly Lesson Development Coworking Sessions, which are a good opportunity to engage with other lesson developers and make regular progress on your project. The sessions are listed on [The Carpentries community calendar](https://carpentries.org/community/#community-events).


### PR DESCRIPTION
Update slack links to point to the new domain URL and invite app.