### PR TITLE
remove redundancy of content about formative assessment

### DIFF
--- a/episodes/exercises.md
+++ b/episodes/exercises.md
@@ -207,25 +207,6 @@ format the MCQ you designed previously as an exercise in your lesson site.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Some other types of formative assessment include:
-
-- **Think, pair, share** - learners _think_ about an answer to a question, _pair_ up
-with a classmate to discuss their answer, and then _share_ out the consensus they came to
-with the class.
-- **Sticky/post-it notes and written feedback** - learners each get two colors of sticky notes.
-If they fall behind or run into an issue, they can put up the
-color that signals they need help.
-If they have completed and exercise or think the instructor could speed up, they put their
-other sticky note up.
-Then at breaks these stickies can turn into written feedback **minute cards**, where the learner
-writes down one thing they were confused about or that could be improved and one thing that went well
-or they really liked learning.
-- **Reflective assessment** - learners spend time reflecting on what they have learned so far.
-Reflection aids in transferring newly learned concepts into long-term memory and can be really helpful for *metacognition*, where learners think about the process of learning, becoming aware of their progress towards acquiring new skills.
-Developing metacognition improves learners' ability to guide their own learning on a topic after they have finished the lesson.
-Reflection exercises can include using what was taught to label a diagram, draw a concept map, free write, or fill in a guided worksheet.
-
-
 
 ::::::::::::::::::::::::::::::::::::::  challenge
 

--- a/episodes/formative-assessment.md
+++ b/episodes/formative-assessment.md
@@ -75,6 +75,9 @@ Any instructional tool that generates feedback and is used in a formative way to
 - **reflection** at the end of a session to help process learning - e.g. asking learners to write down things they learned, things they want to know more about and any questions they still have
 - **concept maps and diagrams** - asking learners to reflect by drawing/labeling a concept map/diagram or writing down a list of new concepts and skills they’ve learned and (optionally) how they relate to one another or connect with previous knowledge
 - **checking in** - gauging learners’ satisfaction and understanding using agreed signals (e.g. raising different coloured post-it/sticky notes or [Zoom reactions](https://coderefinery.github.io/manuals/zoom-mechanics/#reactions) to indicate that the pace is too fast/slow, that they completed/have not completed an exercise).
+- **think, pair, share** - learners _think_ about an answer to a question, _pair_ up
+with a classmate to discuss their answer, and then _share_ out the consensus they came to
+with the class.
 
 Many other formative assessment tools can be found in Briggs’ list of ["21 ways to check for student understanding"](https://www.opencolleges.edu.au/informed/features/21-ways-to-check-for-student-understanding/) or Edutopia's ["56 Examples of Formative Assessment"](https://www.edutopia.org/groups/assessment/250941).
 


### PR DESCRIPTION
Fixes #219 by removing the largely redundant chunk of content about non-exercise types of formative assessment in _Designing Assessments_. I like the mention of _think, pair, share_ though, so have suggested to add that to the list in _Stay on Target_.
