### PR TITLE
Explanation on YAML key-value pairs.

### DIFF
--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -202,7 +202,7 @@ As well as the title of the lesson,
 you can and should adjust some of the other values in `config.yaml`,
 but you should not need to add new values or learn a lot about YAML
 to be able to configure your lesson. You should also only have to add or modify single-line 
-string values and not deal with multi-line strings or other data types (e.g. numbers, booleans, lists, dictionaries) 
+string values and list entries, and not deal with multi-line strings or other data types (e.g. numbers, booleans, dictionaries) 
 that YAML supports. YAML generally does not require quotes (both single (') or double (") are allowed) around string values unless 
 strings contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/), though it may be good practice 
 from readability point of view to use quotes if your string contains several words.

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -198,6 +198,7 @@ The lesson title can be adjusted by modifying the `config.yaml` file in the repo
 The `config.yaml` file contains several global parameters for a lesson -
 to determine some of the page styling, contact details for the lesson, etc. 
 `config.yaml` is written in _[YAML]_, a structured file format of key-value pairs in the form `key: value`.
+(E.g. a YAML file of personal data might include lines such as `name: 'Mei'`, `height_m: 1.84`, and `birthdate: 1899-01-12`.)
 As well as the title of the lesson,
 you can and should adjust some of the other values in `config.yaml`,
 but you should not need to add new values or learn a lot about YAML

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -204,8 +204,8 @@ but you should not need to add new values or learn a lot about YAML
 to be able to configure your lesson. You should also only have to add or modify single-line 
 string values and not deal with multi-line strings or other data types (e.g. numbers, booleans, lists, dictionaries) 
 that YAML supports. YAML generally does not require quotes around string values unless 
-they contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/). It may also be good practice 
-from the readibility point of view to use quotes if your string contains several words.
+they contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/) though it may be good practice 
+from readability point of view to use quotes if your string contains several words.
 
 ::: challenge
 

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -203,7 +203,7 @@ you can and should adjust some of the other values in `config.yaml`,
 but you should not need to add new values or learn a lot about YAML
 to be able to configure your lesson. You should also only have to add or modify single-line 
 string values and not deal with multi-line strings or other data types (e.g. numbers, booleans, lists, dictionaries) 
-that YAML supports. YAML generally does not require quotes around string values unless 
+that YAML supports. YAML generally does not require quotes (both single (') or double (") are allowed) around string values unless 
 they contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/) though it may be good practice 
 from readability point of view to use quotes if your string contains several words.
 

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -196,12 +196,16 @@ You may need to wait a few minutes for the website to be generated.
 
 The lesson title can be adjusted by modifying the `config.yaml` file in the repository.
 The `config.yaml` file contains several global parameters for a lesson -
-to determine some of the page styling, contact details for the lesson, etc -
-and is written in _[YAML]_, a structured file format of key-pair values.
+to determine some of the page styling, contact details for the lesson, etc. 
+`config.yaml` is written in _[YAML]_, a structured file format of key-value pairs in the form `key: value`.
 As well as the title of the lesson,
 you can and should adjust some of the other values in `config.yaml`,
 but you should not need to add new values or learn a lot about YAML
-to be able to configure your lesson.
+to be able to configure your lesson. You should also only have to add or modify single-line 
+string values and not deal with multi-line strings or other data types (e.g. numbers, booleans, lists, dictionaries) 
+that YAML supports. YAML generally does not require quotes around string values unless 
+they contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/). It may also be good practice 
+from the readibility point of view to use quotes if your string contains several words.
 
 ::: challenge
 

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -204,7 +204,7 @@ but you should not need to add new values or learn a lot about YAML
 to be able to configure your lesson. You should also only have to add or modify single-line 
 string values and not deal with multi-line strings or other data types (e.g. numbers, booleans, lists, dictionaries) 
 that YAML supports. YAML generally does not require quotes (both single (') or double (") are allowed) around string values unless 
-strings contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/) though it may be good practice 
+strings contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/), though it may be good practice 
 from readability point of view to use quotes if your string contains several words.
 
 ::: challenge

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -203,9 +203,12 @@ you can and should adjust some of the other values in `config.yaml`,
 but you should not need to add new values or learn a lot about YAML
 to be able to configure your lesson. You should also only have to add or modify single-line 
 string values and list entries, and not deal with multi-line strings or other data types (e.g. numbers, booleans, dictionaries) 
-that YAML supports. YAML generally does not require quotes (both single (') or double (") are allowed) around string values unless 
-strings contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/), though it may be good practice 
-from readability point of view to use quotes if your string contains several words.
+that YAML supports. 
+The template `config.yaml` aims to guide users through examples and annotations
+on how to format the values they provide
+e.g. if you are modifying a value wrapped in quotation marks in the template file,
+it is safest to replace it with another value within quotation marks.
+([Details about when values need to be quoted in YAML](https://www.w3schools.io/file/yaml-escape-characters/).)
 
 ::: challenge
 

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -209,7 +209,6 @@ The template `config.yaml` aims to guide users through examples and annotations
 on how to format the values they provide
 e.g. if you are modifying a value wrapped in quotation marks in the template file,
 it is safest to replace it with another value within quotation marks.
-([Details about when values need to be quoted in YAML](https://www.w3schools.io/file/yaml-escape-characters/).)
 
 ::: challenge
 

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -204,7 +204,7 @@ but you should not need to add new values or learn a lot about YAML
 to be able to configure your lesson. You should also only have to add or modify single-line 
 string values and not deal with multi-line strings or other data types (e.g. numbers, booleans, lists, dictionaries) 
 that YAML supports. YAML generally does not require quotes (both single (') or double (") are allowed) around string values unless 
-they contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/) though it may be good practice 
+strings contain [reserved characters](https://www.w3schools.io/file/yaml-escape-characters/) though it may be good practice 
 from readability point of view to use quotes if your string contains several words.
 
 ::: challenge

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -198,7 +198,7 @@ The lesson title can be adjusted by modifying the `config.yaml` file in the repo
 The `config.yaml` file contains several global parameters for a lesson -
 to determine some of the page styling, contact details for the lesson, etc. 
 `config.yaml` is written in _[YAML]_, a structured file format of key-value pairs in the form `key: value`.
-(E.g. a YAML file of personal data might include lines such as `name: 'Mei'`, `height_m: 1.84`, and `birthdate: 1899-01-12`.)
+For example, a YAML file of personal data might include lines such as `name: 'Mei'`, `height_m: 1.84`, and `birthdate: 1899-01-12`.
 As well as the title of the lesson,
 you can and should adjust some of the other values in `config.yaml`,
 but you should not need to add new values or learn a lot about YAML


### PR DESCRIPTION
Fixes #246.

I remembered Ann asking about quotes around strings in last week's trainer training so I added an explanation on that - but feel like any text I add either opens another line of questions / further reading (e.g. mentioning of different data types in YAML) or is not 100% complete/correct (e.g. quoting strings is not the only way to deal with special/reserved characters in YAML). 

