### PR TITLE
94 hidden curriculum

### DIFF
--- a/episodes/formative-assessment.md
+++ b/episodes/formative-assessment.md
@@ -32,17 +32,13 @@ with step 2, 'Design assessments for these outcomes' highlighted."
 width="67%"
 }
 
-As we have seen previously, defining objectives for a lesson (or a teaching episode) can help to focus your content on the most important learning outcomes and outline the scope of your lesson project. With learning objectives you have defined your **intended (or planned) curriculum** - what you set out to accomplish with your lesson. The skills and knowledge your learners actually leave with and can demonstrate after the workshop having followed the **implemented curriculum** in the classroom is called the **attained curriculum**. **Implemented curriculum** includes the concepts, relationships and skills that are explicitly covered in your lesson and translated into classroom practices - i.e. the teaching and learning activities that should lead to your learners attaining knowledge.
-
-::::::::::::::::::::::::::::::::::::::  callout
-
-## Hidden Curriculum
-
-There is one more curriculum at play here - **hidden curriculum** includes all unintended curricular effects that influence learning but are not explicitly  addressed in the lesson content - e.g. (unofficial) social and cultural norms, behaviours and values that are transferred by instructors to learners, often unconsciously. These are all the additional things that people learn about the topic from *the way* your lesson is taught, rather than from its official content. You can use Instructor Notes (covered in more detail in ["Preparing to Teach"](preparing.md) episode) to guide instructors on some of the aspects of the hidden curriculum, e.g. to encourage them to follow certain tried and tested practices.
-
-::::::::::::::::::::::::::::::::::::::::::::::::::
-
-The goal of the remaining steps of lesson development is to ensure that the attained curriculum matches the intended curriculum as closely as possible. To do so, you need to develop assessments to ensure progression towards your learning outcomes.
+As we have seen previously, defining objectives for a lesson (or a teaching episode) can 
+help to focus your content on the most important learning outcomes 
+and outline the scope of your lesson project. 
+The goal of the remaining steps of lesson development is to ensure that 
+what learners learn from following your lesson 
+matches its defined objectives as closely as possible. 
+To do so, you need to develop assessments to monitor progression towards your learning outcomes.
 
 ::::::::::::::::::::::::::::::::::::::  callout
 

--- a/episodes/preparing.md
+++ b/episodes/preparing.md
@@ -113,6 +113,24 @@ Another standard piece of The Carpentries Workbench are the *Instructor Notes* p
 
 It may initially be difficult to create Instructor Notes until you have taught the lesson yourself for the first time - but after the first pilot you will have enough feedback to draft them.
 
+::::::::::::::::::::::::::::::::::::::  callout
+
+## Hidden Curriculum
+
+The concept of **hidden curriculum** describes curricular effects that influence learning 
+but are not explicitly addressed in the lesson content - 
+e.g. (unofficial) social and cultural norms, behaviours and values 
+that are transferred by instructors to learners, often unconsciously.
+These are all the additional things that people learn about the topic from *the way* your lesson is taught, 
+rather than from its official content.
+It is worthwhile to spend some time thinking about what learners could pick up
+from _the way_ your lesson is taught,
+as well as from its written content. 
+You can use Instructor Notes to guide instructors on some of the aspects of the hidden curriculum of your lesson,
+e.g. to encourage them to follow certain tried and tested practices.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 ::::::::::::::::::::::::::::::::::::::  challenge
 
 ## Exercise: Add Instructor Notes (5 minutes)

--- a/learners/further-reading.md
+++ b/learners/further-reading.md
@@ -1,0 +1,13 @@
+---
+title: Further Reading
+---
+
+## Intended, Implemented, Hidden, and Attained Curriculum
+
+(See [Course design: Considerations for Trainers – a Professional Guide](https://f1000research.com/documents/9-1377) for more details.)
+
+- **Intended curriculum**: the skills and knowledge you plan to teach with your lesson.
+- **Implemented curriculum**: the content you design to teach the _intended curriculum_.
+- **Attained curriculum**: the skills and knowledge people actually learn from your lesson.
+- **Hidden curriculum**: skills and knowledge the lesson teaches that were not part of the intended curriculum,
+  e.g. about social and/or cultural norms associated with the subject matter of the lesson.


### PR DESCRIPTION
Fixes #94 by moving the callout about hidden curriculum to _Preparing to Teach_, where it makes sense alongside the discussion of Instructor Notes.

In the second commit, I added a new "extra" page to the Learner View, to capture material for further reading if any trainees are particularly interested in digging into more details on some of the concepts introduced in CLDT. If you think this extra page is not desirable, I am happy to revert that commit.