### PR TITLE
Add table with lesson development infrastructure overview

### DIFF
--- a/episodes/operations.md
+++ b/episodes/operations.md
@@ -51,8 +51,8 @@ in the Incubator is ready to be incorporated into one of The Carpentries _Lesson
 the collection of lessons and curricula that can be taught in an official workshop for
 Software, Library, or Data Carpentry.
 
-|                                       | Incubator          | Lab                |
-| ------------------------------------- | ------------------ | ------------------ |
+|                                       | Incubator | Lab |
+|:--------------------------------------|:---:|:---:|
 | lesson owned by community             | :heavy_check_mark: | :heavy_check_mark: |
 | lesson under development              | :heavy_check_mark: | :x:                |
 | lesson stable                         | :x:                | :heavy_check_mark: |

--- a/episodes/operations.md
+++ b/episodes/operations.md
@@ -60,6 +60,7 @@ Software, Library, or Data Carpentry.
 | CC-BY license                         | :heavy_check_mark: | :heavy_check_mark: |
 | The Carpentries Code of Conduct       | :heavy_check_mark: | :heavy_check_mark: |
 | The Carpentries lesson infrastructure | :heavy_check_mark: | :heavy_check_mark: |
+Table: Summary of community-developed lessons in The Carpentries Incubator and Lab.
 
 
 ## The Lesson Life Cycle

--- a/episodes/operations.md
+++ b/episodes/operations.md
@@ -51,6 +51,16 @@ in the Incubator is ready to be incorporated into one of The Carpentries _Lesson
 the collection of lessons and curricula that can be taught in an official workshop for
 Software, Library, or Data Carpentry.
 
+|                                       | Incubator          | Lab                |
+| ------------------------------------- | ------------------ | ------------------ |
+| lesson owned by community             | :heavy_check_mark: | :heavy_check_mark: |
+| lesson under development              | :heavy_check_mark: | :x:                |
+| lesson stable                         | :x:                | :heavy_check_mark: |
+| lesson has passed peer review         | :x:                | :heavy_check_mark: |
+| CC-BY license                         | :heavy_check_mark: | :heavy_check_mark: |
+| The Carpentries Code of Conduct       | :heavy_check_mark: | :heavy_check_mark: |
+| The Carpentries lesson infrastructure | :heavy_check_mark: | :heavy_check_mark: |
+
 
 ## The Lesson Life Cycle
 


### PR DESCRIPTION
Fixes https://github.com/carpentries/lesson-development-training/issues/183

I made a couple of changes to the table proposed in #183. 
- moved "lesson owned by community" to top as it seemed to flow better to me
- changed "lesson stable" to be an X in the Incubator column and a check in the lab column
