### PR TITLE
247 improve config exercise

### DIFF
--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -214,7 +214,9 @@ it is safest to replace it with another value within quotation marks.
 
 ### Practice with `config.yaml` (5 minutes)
 
-Complete the configuration of your lesson by adjusting the following fields in `config.yaml`:
+Complete the configuration of your lesson by adjusting the following fields in `config.yaml`. 
+Remember that FIXME values with quotes should be replaced with another value still in quotes and 
+FIXMEs without quotes should be replaced by values without quotes.
 
 - `contact`: add an email address people can contact with questions about the lesson/project.
 - `created`: the date the lesson was created (today's date) in YYYY-MM-DD format.

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -216,10 +216,11 @@ it is safest to replace it with another value within quotation marks.
 
 Complete the configuration of your lesson by adjusting the following fields in `config.yaml`:
 
-- `email`: add an email address people can contact with questions about the lesson/project.
+- `contact`: add an email address people can contact with questions about the lesson/project.
 - `created`: the date the lesson was created (today's date) in YYYY-MM-DD format.
 - `keywords`: a (short) list of keywords for the lesson,
-   which can help people find your lesson when searching for resources online.
+   which can help people find your lesson when searching for resources online. At a minimum,
+  include 'lesson', ‘carpentries-incubator’, your lesson's life-cycle stage, and your lesson's (human) language.
 - `source`: change this to the URL for your lesson repository.
 
 We will revisit the `life_cycle` and `carpentry` fields in `config.yaml` later in this training.

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -220,7 +220,7 @@ FIXMEs without quotes should be replaced by values without quotes.
 
 - `contact`: add an email address people can contact with questions about the lesson/project.
 - `created`: the date the lesson was created (today's date) in YYYY-MM-DD format.
-- `keywords`: a (short) list of keywords for the lesson,
+- `keywords`: a (short) comma-separated list of keywords for the lesson,
    which can help people find your lesson when searching for resources online. At a minimum,
   include 'lesson', ‘carpentries-incubator’, your lesson's life-cycle stage, and your lesson's (human) language.
 - `source`: change this to the URL for your lesson repository.

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -222,7 +222,7 @@ FIXMEs without quotes should be replaced by values without quotes.
 - `created`: the date the lesson was created (today's date) in YYYY-MM-DD format.
 - `keywords`: a (short) comma-separated list of keywords for the lesson,
    which can help people find your lesson when searching for resources online. At a minimum,
-  include 'lesson', ‘carpentries-incubator’, your lesson's life-cycle stage, and your lesson's (human) language.
+  include 'lesson', 'pre-alpha', and your lesson's (human) language. For example, 'lesson, pre-alpha, español'.
 - `source`: change this to the URL for your lesson repository.
 
 We will revisit the `life_cycle` and `carpentry` fields in `config.yaml` later in this training.


### PR DESCRIPTION
Addresses https://github.com/carpentries/lesson-development-training/issues/247

Also: 
- Replaces 'email' with 'contact' as that is the value name in the current workbench template.  
<img width="581" alt="Screenshot 2023-09-12 at 1 49 36 PM" src="https://github.com/carpentries/lesson-development-training/assets/19176319/fc39c450-fcb4-462c-8e72-194d125cbb1d">
- Provides guidance on what keywords to include. 
