### PR TITLE
Add time for troubleshooting builds

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,8 +49,8 @@ episodes:
 - audience.md
 - short-break1.md
 - objectives.md
-- long-break1.md
 - episodes.md
+- long-break1.md
 - infrastructure.md
 - short-break2.md
 - episode-objectives.md

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -1,6 +1,6 @@
 ---
 title: The Carpentries Workbench
-teaching: 45
+teaching: 60
 exercises: 20
 ---
 
@@ -498,6 +498,18 @@ Using this approach, we can build up our lesson one episode at a time.
 
 We have now learned everything we need to be able to use The Carpentries Workbench,
 and our focus can return to the process of developing a new lesson.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
+
+## Troubleshoot Lesson Builds (~10 mins)
+
+This is a good opportunity to pause and check in on 
+how well trainees' lesson builds are running.
+If anyone is having trouble with their workflows, 
+ask them to share their screen 
+and try following the troubleshooting steps to diagnose and fix the issue.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
Fixes #78 by adding time for troubleshooting builds.

This PR moves the Episodes episode to the end of the first half-day, to allow time for the troubleshooting.

(#286 should be merged before this one. I will probably need to resolve conflicts.)