### PR TITLE
Moved gh-pages activation to instructor note

### DIFF
--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -200,7 +200,7 @@ The `gh-pages` branch should never be modified by anyone other than the automate
 
 :::
 
-On repository home page
+On the repository home page
 (e.g. by clicking the name of the project near the top left of the window),
 click the gear wheel icon near the top right, to edit the _About_ box.
 Check the box that says "Use your GitHub Pages website" to add the address of your lesson site to the About box.

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -172,6 +172,11 @@ For now, we will move on to complete the basic setup of the lesson.
 
 ### Configuring a Lesson Repository
 
+Since the lesson was created with a `gh-pages` branch.  It should already be generating a rendered version
+of the template repository.  If it isn't, the instructor should work with groups to turn on GitHub Pages.
+
+::::::::::::: instructor
+
 #### Activating GitHub Pages
 
 We need to tell GitHub to begin serving the lesson website via GitHub Pages.
@@ -179,6 +184,8 @@ To do this, navigate to _Settings_, then choose _Pages_ from the left sidebar.
 Under _Source_, choose the `gh-pages` branch, leave the folder set to `/ (root)`,
 and click _Save_.
 You may copy the URL in this box, this will be the address of your lesson site.
+
+::::::::::::::::::::::::
 
 ::: callout
 
@@ -193,13 +200,14 @@ The `gh-pages` branch should never be modified by anyone other than the automate
 
 :::
 
-Returning to the repository home page
+On repository home page
 (e.g. by clicking the name of the project near the top left of the window),
 click the gear wheel icon near the top right, to edit the _About_ box.
 Check the box that says "Use your GitHub Pages website" to add the address of your lesson site to the About box.
 
 After following these steps, when you navigate to the pages URL, you should see a lesson website with The Carpentries logo and "Lesson Title" in the top-left corner.
 You may need to wait a few minutes for the website to be generated.
+
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
 


### PR DESCRIPTION
Fixes #242

Made a couple of small changes to move the gh-pages activation section to an instructor note.  Think the callout and adding to the about in settings is still relevant. 
I was a little conflicted. Since the `gh-pages` should be generated and autodetected by GitHub Pages as the branch to render, maybe this instructor note should be how to force the `gh-pages` branch to be build if you only have a `main` branch?