### PR TITLE
inline link to CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 title: "Contributor Code of Conduct"
 ---
 As contributors and maintainers of this project,
-we pledge to follow the [Carpentry Code of Conduct][coc].
+we pledge to follow the [Carpentry Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
 
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by following our [reporting guidelines][coc-reporting].


### PR DESCRIPTION
When I asked @sstevens2 to de-duplicate the link references in #291, I forgot that this Markdown file needs to be self-contained so that people can find the Code of Conduct from the repository. This PR re-adds the link to the CoC page as an inline link in the file.