### PR TITLE
Prepare beta release

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,0 @@
-- [Toby Hodges](https://github.com/tobyhodges), The Carpentries
-- [Mateusz Kuzak](https://github.com/mkuzak), The Netherlands eScience Center
-- [Aleksandra Nenadic](https://github.com/anenadic), UK Software Sustainability Institute
-- [Sarah Stevens](https://github.com/sstevens2), University of Wisconsin–Madison
-- [Jamene Brooks-Kieffer](https://github.com/jbkieffer), University of Kansas

--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,0 @@
-FIXME: describe how to cite this lesson.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,121 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: The Carpentries Collaborative Lesson Development Training
+message: >-
+  Please cite this curriculum using the information in this
+  file if you publish a lesson/curriculum after using this
+  curriculum or attending a training where it was taught.
+type: dataset
+authors:
+  - given-names: Erin
+    family-names: Becker
+    affiliation: The Carpentries
+    orcid: 'https://orcid.org/0000-0002-6832-0233'
+  - given-names: Yanina
+    name-particle: Noemí
+    family-names: Bellini Saibene
+    affiliation: ROpenSci
+    orcid: 'https://orcid.org/0000-0002-4522-7466'
+  - orcid: 'https://orcid.org/0000-0001-6280-124X'
+    given-names: Jamene
+    family-names: Brooks-Kieffer
+    affiliation: University of Kansas
+  - given-names: Ben
+    family-names: Companjen
+    affiliation: Leiden University Libraries
+    orcid: 'https://orcid.org/0000-0002-7023-9047'
+  - given-names: Rob
+    family-names: Davey
+    affiliation: The Carpentries
+    orcid: 'https://orcid.org/0000-0002-5589-7754'
+  - given-names: Toby
+    family-names: Hodges
+    email: tobyhodges@carpentries.org
+    affiliation: The Carpentries
+    orcid: 'https://orcid.org/0000-0003-1766-456X'
+  - given-names: Zhian
+    family-names: Kamvar
+    affiliation: The Carpentries
+    orcid: 'https://orcid.org/0000-0003-1458-7108'
+  - given-names: Mateusz
+    family-names: Kuzak
+    affiliation: The Netherlands eScience Center
+    orcid: 'https://orcid.org/0000-0003-0087-6021'
+  - given-names: Aleksandra
+    family-names: Nenadic
+    affiliation: >-
+      Software Sustainability Institute / The University of
+      Manchester
+    orcid: 'https://orcid.org/0000-0002-2269-3894'
+  - given-names: Sarah
+    family-names: Stevens
+    affiliation: The University of Wisconsin-Madison
+    orcid: 'https://orcid.org/0000-0002-7040-548X'
+  - given-names: Angelique
+    family-names: Trusler
+    affiliation: The Carpentries
+    orcid: 'https://orcid.org/0000-0003-2340-8538'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.8410626
+    description: Zenodo Concept DOI (always resolves to latest version)
+repository-code: 'https://github.com/carpentries/lesson-development-training'
+url: 'https://carpentries.github.io/lesson-development-training'
+abstract: >
+  A training curriculum teaching good practices in lesson
+  design and development, and open source collaboration
+  skills, using The Carpentries Workbench. The curriculum is
+  designed to be taught over six half-days. The target
+  audience is Carpentries Instructors with an idea for a new
+  lesson they would like to create, especially if that
+  lesson is intended for short-format training (e.g. part or
+  all of a two-day workshop).
+
+  We believe that lesson development is easier and more
+  successful when it is a joint effort among collaborators,
+  so the activities and examples used in this training are
+  best suited to groups of trainees who want to collaborate
+  on a lesson project. Efforts have been made to also cater
+  to lesson developers working alone.
+
+  After attending this training, participants will be able
+  to:
+
+  * collaboratively develop and publish lessons using The
+  Carpentries lesson infrastructure (aka The Carpentries
+  Workbench): lesson template, GitHub, GitHub Pages, etc.
+
+  * identify and characterise the target audience for a
+  lesson.
+
+  * define SMART learning objectives.
+
+  * explain the pedagogical value of authentic tasks.
+
+  * create exercises for formative assessment.
+
+  * explain how considerations of cognitive load can
+  influence the pacing, length, and organisation of a
+  lesson.
+
+  * configure and maintain accessible and usable lesson
+  repositories using best practices, readily available for
+  collaboration.
+
+  * identify and correct accessibility issues in a
+  Carpentries lesson.
+
+  * update and improve lesson material guided by feedback
+  and reflection from teaching.
+
+  * review and provide constructive feedback on lessons.
+keywords:
+  - carpentries
+  - curriculum-development
+  - backward-design
+  - collaboration-skills
+license: CC-BY-4.0
+version: v2023-beta
+date-released: '2023-10-09'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Collaborative Lesson Development Training Curriculum
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8410626.svg)](https://doi.org/10.5281/zenodo.8410626)
 [![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
 [![Build and Deploy Site](https://github.com/carpentries/lesson-development-training/actions/workflows/sandpaper-main.yaml/badge.svg)](https://github.com/carpentries/lesson-development-training/actions/workflows/sandpaper-main.yaml)
 
-Curriculum for a short (~3 days) workshop teaching skills required for
+
+Curriculum for a short (six half days) workshop teaching skills required for
 collaborative lesson development. The lesson is visible at: https://carpentries.github.io/lesson-development-training/.
 
-**This curriculum is currently being piloted.**
 If you are interested in helping us develop this material,
 teaching the curriculum,
 or attending a Collaborative Lesson Development Training workshop,
@@ -14,7 +15,6 @@ please [contact Toby Hodges](mailto:tobyhodges@carpentries.org).
 
 
 ## Contributing
-
 Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for contributing guidelines and details on how to get involved with this project.
 
 Also see the current list of [issues](https://github.com/carpentries/lesson-development-training/issues)
@@ -25,11 +25,8 @@ and is a good opportunity for a new contributor to get involved.
 
 To learn more about how this lesson site is built and how you can edit the pages, see [the Introduction to The Carpentries Workbench][sandpaper-docs].
 
-## Author(s)
-The list of authors of the lesson is available in [AUTHORS.md](AUTHORS.md).
 
 ## Maintainer(s)
-
 Current Maintainers of this lesson are:
 
 * [Toby Hodges](https://github.com/tobyhodges) (Lead Maintainer)
@@ -39,31 +36,34 @@ Current Maintainers of this lesson are:
 
 The Maintainer Team aims to meet at 12:00 UTC on the fourth Friday of each month.
 
-## Acknowledgements
 
+## Acknowledgements
 The following people aided the development of this curriculum,
 by providing suggestions, reviews, and inspiration:
 
 * [Allegra Via](https://github.com/allegravia)
 * [Angelique Trusler](https://github.com/elletjies)
+* [Ann Backhaus](https://github.com/AnnBackhaus)
 * [Erin Becker](https://github.com/erinbecker)
 * [François Michonneau](https://github.com/fmichonneau)
 * [Greg Wilson](https://github.com/gvwilson)
 * [Karen Word](https://github.com/karenword)
 * [Kate Hertweck](https://github.com/k8hertweck)
 * [Kelly Barnes](https://github.com/klbarnes20)
+* [Mike Trizna](https://github.com/miketrizna)
 * [Sue McClatchy](https://github.com/smcclatchy)
 * [Tim Dennis](https://github.com/jt14den)
 * [Yanina Bellini Saibene](https://github.com/yabellini)
 * [Yuka Takemon](https://github.com/ytakemon)
 * [Zhian Kamvar](https://github.com/zkamvar)
 
-## Citation
 
-Citation info coming soon...
+## Citation
+See [CITATION.cff](CITATION.cff) for citation information.
+([Read more about the Citation File Format and how to use it](https://citation-file-format.github.io/).)
+
 
 ## Contact
-
 Please get in touch with [Toby Hodges](tobyhodges@carpentries.org) with any questions about this lesson.
 
 [sandpaper-docs]: https://carpentries.github.io/sandpaper-docs/

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ by providing suggestions, reviews, and inspiration:
 
 
 ## Citation
-See [CITATION.cff](CITATION.cff) for citation information.
+See [CITATION.cff](CITATION.cff) for citation information, including a list of authors.
 ([Read more about the Citation File Format and how to use it](https://citation-file-format.github.io/).)
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -12,9 +12,15 @@ carpentry: "cp"
 # Overall title for pages.
 title: "Collaborative Lesson Development Training"
 
+# Date the lesson was created (YYYY-MM-DD, this is empty by default)
+created: 2022-01-18
+
+# Comma-separated list of keywords for the lesson
+keywords: 'carpentries, curriculum-development, backward-design, collaboration-skills'
+
 # Life cycle stage of the lesson
 # possible values: pre-alpha, alpha, beta, stable
-life_cycle: alpha
+life_cycle: beta
 
 # License of the lesson
 license: CC-BY 4.0
@@ -76,7 +82,6 @@ episodes:
 
 # Information for Learners
 learners:
-- setup.md
 - pilot-description.md
 - markdown-github-primer.md
 - trial-runs.md
@@ -87,4 +92,3 @@ instructors:
 
 # Learner Profiles
 profiles:
-


### PR DESCRIPTION
- Adds a `CITATION.cff` file, listing everyone who has committed as an author (ordered alphabetically by family name)*
- Updates the `config.yaml` and `README.md` files to reflect the new status of the curriculum
- Removes the `AUTHORS.md` and `CITATION` files, rendered obsolete by the CFF file

\* in the next release (stable), the CFF specification should have been updated to allow for a `contributors` field, which we can use to list all the people (currently named in the README) who have contributed to the project but are not represented in the commit history.