### PR TITLE
fix icebreaker link

### DIFF
--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -57,7 +57,7 @@ Do not force people to share their pronouns.
 ### Getting to Know Each Other
 
 If the Trainer has chosen an
-[icebreaker question](https://carpentries.github.io/instructor-training/icebreakers/index.html),
+[icebreaker question](https://carpentries.github.io/instructor-training/icebreakers.html),
 participate by writing your answers in the shared document for the workshop.
 
 :::


### PR DESCRIPTION
if the expected behaviour is that the link within these two callouts works the same:
- https://carpentries.github.io/lesson-development-training/aio.html#before-the-training-begins
- https://carpentries.github.io/instructor-training/01-welcome.html#before-the-course-begins

then, the link could be redirected to https://carpentries.github.io/instructor-training/icebreakers.html