### PR TITLE
Add issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,23 @@
+name: Report a problem
+description: Tell us about something that needs to be fixed
+body:
+  - type: textarea
+    id: details
+    attributes:
+      label: What is the problem?
+      description: Please provide details, to make it easier for the Maintainers and other community members to address the issue.
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Location of problem (optional)
+      description: Where is the problem that needs to be fixed? (e.g. the name of the source file or the URL(s) of the webpage(s))
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking time to tell us about a problem in this repository.
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+        Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
+        If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 
+        please contact The Carpentries Team at team@carpentries.org.

--- a/.github/ISSUE_TEMPLATE/suggest_improvement_1_lesson.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_improvement_1_lesson.yml
@@ -1,0 +1,19 @@
+name: Suggest a curriculum-wide improvement
+description: Tell us about how the content of the curriculum as a whole could be improved
+body:
+  - type: textarea
+    id: details
+    attributes:
+      label: How could the content be improved?
+      description: Please provide details of the improvement you are suggesting, to make it easier for the Maintainers and other community members to address the issue.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking time to suggest an improvement to this repository.
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+        
+        Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
+        If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 
+        please contact The Carpentries Team at team@carpentries.org.

--- a/.github/ISSUE_TEMPLATE/suggest_improvement_2_episode.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_improvement_2_episode.yml
@@ -1,0 +1,24 @@
+name: Suggest an improvement in a specific location
+description: Tell us about how a particular section of the curriculum could be improved
+body:
+  - type: textarea
+    id: details
+    attributes:
+      label: How could the content be improved?
+      description: Please provide details of the improvement you are suggesting, to make it easier for the Maintainers and other community members to address the issue.
+    validations:
+      required: true
+  - type: input
+    id: location-details
+    attributes:
+      label: Which part of the content does your suggestion apply to?
+      description: Please provide a URL, the title of the relevant section or page, a filename, etc.
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking time to suggest an improvement to this repository.
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+        
+        Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
+        If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 
+        please contact The Carpentries Team at team@carpentries.org.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
+
+
+_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
+
+
+_If any relevant discussions have taken place elsewhere, please provide links to these._
+
+
+<details>
+
+For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+
+Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.
+
+</details>


### PR DESCRIPTION
Closes #348 by adding templates for issues and PRs that are more relevant to this lesson repository than the standard templates provided at https://github.com/carpentries/.github/