### PR TITLE
enable Matomo tracking for testing purposes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,3 +92,6 @@ instructors:
 
 # Learner Profiles
 profiles:
+
+# Enabling Matomo tracking for testing purposes
+varnish: tobyhodges/varnish@test-self-hosted-matomo


### PR DESCRIPTION
FYI @anenadic @sstevens2 I am merging this as a step towards testing self-hosted web analytics for Carpentries lessons.