### PR TITLE
Add content about CFF files for lesson citation

### DIFF
--- a/episodes/collaborating-newcomers.md
+++ b/episodes/collaborating-newcomers.md
@@ -43,9 +43,22 @@ Your lesson documentation should contain the following information, which should
 - **contact information** - include up-to-date email addresses or mailing lists or other details on how to get in touch with the lesson maintainers
 - **contributing information** - this is an opportunity to list what kinds of contributions are sought (and what are not) and how to get involved in lesson development for new contributors. You can provide more details in a separate `CONTRIBUTING` file within the repository’s root directory and link to it from `README`
 - **credits/acknowledgements** - make sure to credit those who have helped in the lesson's development or inspired it, and/or any resources/templates that you have reused. You can also link to a separate `AUTHORS.md` file within the repository’s root directory to list all the people who contributed to the lesson content (if this list starts to become too large to include in the `README` itself)
-- **citation** - a convention is to include the citation information for your lesson in a separate `CITATION` file within the repository’s root directory (and link to it from `README`) so others can cite the use of the lesson in their own publications and media and it can also be automatically discovered by other applications. Citation can be a Digital Object Identifier (DOI) issued by a reputable DOI-issuing repository such as [Zenodo](https://zenodo.org/), which should be obtained as a permanent identifier as soon as your lesson reaches the beta stage, or an appropriate academic publication once your lesson becomes stable and is peer-reviewed.
-Citation can be contained in a plain text file (`CITATION`, `CITATION.txt`), a Markdown file (`CITATION.md`), or in the recently adopted [Citation File Format](https://github.com/citation-file-format/citation-file-format) (`CITATION.cff`). The CFF is defined using [YAML](https://yaml.org/spec/1.2.2/) (which we already encountered in the `config.yaml` file for the lesson website) and is now [the recommended way of storing citations in GitHub](https://github.blog/2021-08-19-enhanced-support-citations-github/). Advantages of using CFF are that GitHub will automatically show the citation information in the sidebar, making it more visible and accessible for visitors to your repository. In addition, metadata from `CITATION.cff` files will automatically be used by [Zenodo](https://zenodo.org/) when registering the DOI for your lesson/project. CFF metadata is also recognised by the [Zotero reference manager](https://www.zotero.org/).
+- **citation** - a convention is to include the citation information for your lesson in a separate `CITATION` file within the repository’s root directory and link to it from `README.md` so others can cite the use of the lesson in their own publications and media and it can also be automatically discovered by other applications. These `CITATION` files are discussed in more detail below.
 - **license** - a short description of and a link to the lesson’s license typically contained in a separate `LICENSE`, `LICENSE.txt` or `LICENSE.md` file within the repository’s root directory. The lesson repository created from the Carpentries lesson template already contains a default `LICENSE.md` file, but you should modify this to more accurately describe how the lesson content can be re-used by others.
+
+
+### Helping People Cite Your Lesson
+The default citation file for new lessons using The Carpentries Workbench is `CITATION.cff`, in [Citation File Format (CFF)](https://github.com/citation-file-format/citation-file-format). 
+CFF is defined using [YAML](https://yaml.org/spec/1.2.2/) (which we already encountered in the `config.yaml` file for the lesson website) and is [the recommended way of storing citations in GitHub](https://github.blog/2021-08-19-enhanced-support-citations-github/). If your lesson repository contains a `CITATION.cff` file, GitHub will automatically show the citation information in the sidebar, making it more visible and accessible for visitors to your repository. CFF is also recognised and supported by other platforms including [Zenodo](https://zenodo.org/) and the [Zotero reference manager](https://www.zotero.org/).
+
+The `CITATION.cff` file for newly-created lessons contains only placeholder information, which should be replaced with relevant details for your project as soon as practical.
+Citation information can also be contained in a plain text file (`CITATION`, `CITATION.txt`) or a Markdown file (`CITATION.md`). 
+In all cases, it is up to the lesson developers to decide what information to include in their citation file.
+
+#### Digital Object Identifiers
+We recommend that you obtain a [Digital Object Identifier (DOI)](https://the-turing-way.netlify.app/communication/citable/citable-steps.html?highlight=doi#dois) for your lesson as soon as feels appropriate, at the latest when the lesson reaches the beta phase. You can use this DOI in the citation information (e.g. [in the `identifiers` field of your `CITATION.cff`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#identifiers)), to allow people to cite a particular version of your lesson, e.g. a snapshot of the lesson when it entered beta testing, captured as a Zenodo record.
+
+
 
 ### Instructions for Contributors - `CONTRIBUTING` File {#contributing}
 
@@ -79,6 +92,7 @@ Spend some time doing **one of the following**:
    - links to any funding bodies or host institutes that are supporting the development of the lesson (README)
 2. Create a new issue or pull request template, or modify an existing one,
    to guide contributors on how best to begin collaborating with you on GitHub.
+3. Using [the `cffinit` webtool](https://citation-file-format.github.io/cff-initializer-javascript/), create a `CITATION.cff` with information appropriate to your project (listing authors, including the lesson title, repository URL, etc) and overwrite the current placeholder content with the result.
 
 Groups of collaborators taking this training together should discuss first how they will assign these tasks between them.
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -158,6 +158,7 @@ but a few are accompanying files primarily intended for the repository itself
 rather than the lesson website.
 These are:
 
+- `CITATION.cff`
 - `CODE_OF_CONDUCT.md`
 - `CONTRIBUTING.md`
 - `LICENSE.md`


### PR DESCRIPTION
Closes #350 by updating content about lesson citation to reflect CFF as the default for new lessons.