### PR TITLE
remove instruction to add title

### DIFF
--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -348,7 +348,7 @@ of how content will be displayed in your website**.
 
 To get started on this home page,
 replace the template text with
-the same title and short description you added to your `README.md`.
+the same short description you added to your `README.md`.
 
 Below those, you can add the prerequisite skills you determined earlier for your lesson,
 as a bullet point list to `index.md`:


### PR DESCRIPTION
Adding the title to the index page will result in it displaying underneath the "Summary and Setup" heading, which looks weird and doesn't follow the pattern used in our official lessons. The lesson title is already displayed in the lesson header for each episode.
