### PR TITLE
Clarifying spoilers vs callouts and switching callouts to spoilers in this lesson

### DIFF
--- a/episodes/audience.md
+++ b/episodes/audience.md
@@ -152,7 +152,7 @@ to help you assess whether a respondent falls within the intended audience for y
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
-::::::::::: callout
+::::::::::: spoiler
 
 ## Thinking more about target audience
 

--- a/episodes/collaborating-newcomers.md
+++ b/episodes/collaborating-newcomers.md
@@ -121,20 +121,20 @@ Check out [GitHub's documentation on setting notifications on individual reposit
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
 
-## Time management tip: share the next callout, do not teach it
+## Time management tip: share the next spoiler, do not teach it
 
-The next callout contains a lot of information,
+The next spoiler contains a lot of information,
 and can require a lot of time to discuss fully while training.
 We recommend that you do not dwell on these details while teaching
 unless you have time to spare.
 
-Instead, you could share [a link to the callout](#managing-github-notifications) 
+Instead, you could share [a link to the spoiler](#managing-github-notifications) 
 and mention to trainees that this information can be helpful 
 if they are struggling with GitHub notifications.
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::::::::::::::: spoiler
 
 ## Managing GitHub Notifications
 

--- a/episodes/collaborating-team.md
+++ b/episodes/collaborating-team.md
@@ -104,7 +104,7 @@ On GitHub, these units of discussion, review,
 and acceptance/rejection of the changes within a branch
 are called _Pull Requests_.
 
-:::::: callout
+:::::: spoiler
 
 ## Why "Pull Request"?
 
@@ -195,7 +195,7 @@ the Reviewer should follow all the steps but close the PR at the end instead of 
 
 ::::::::::::::::
 
-:::::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::::: spoiler
 
 ### Protecting `main` Branch
 

--- a/episodes/episode-objectives.md
+++ b/episodes/episode-objectives.md
@@ -85,7 +85,7 @@ After completing this episode, participants should be able to...
 :::
 
 
-::: callout
+::: spoiler
 
 ### Full List of Fenced Divs
 

--- a/episodes/explanation.md
+++ b/episodes/explanation.md
@@ -46,17 +46,21 @@ In general, it is not a good idea to assume others, learners or instructors,
 will know what you were thinking when you wrote the content
 so, if in doubt, be explicit.
 
-::::::::::::::::::::::::::::::::::::::::  callout
+::::::::::::::::::::::::::::::::::::::::  spoiler
 
-## Using Callouts
+## Using Spoilers for Optional Materials
 
 Often lessons have more content than can be reasonably taught in the amount of time allotted.
 This is especially true for collaboratively developed lessons as each contributor/instructor
 may have additional items they'd like to see included, leading to "scope creep".
 
-To address this issue, in many Carpentries lessons, callout boxes are used for asides and short tangents,
+To address this issue, in many Carpentries lessons, spoiler boxes are used for asides and short tangents,
 e.g. points that might be relevant to some audiences but are not essential to the flow of the lesson.
-These callouts should still be kept to a minimum as they can be disruptive to instructors and readers.
+These spoilers should still be kept to a minimum as they can be disruptive to instructors and readers.
+
+Note, this use of the spoiler box is to use the expandable box functionality as nothing will be "spoiled"
+by expanding this box.
+Also, note that the spoiler box titles should be very clear so instructors need not expand the spoiler to know if they want to teach that extra
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/explanation.md
+++ b/episodes/explanation.md
@@ -65,6 +65,25 @@ Also, note that the spoiler box titles should be very clear so instructors need 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::: callout
+
+## Calling Attention to Important Points
+
+For important points in the lesson, you can add them to a callout box to emphasize their
+importance.
+
+::::: spoiler
+
+### Inconsistent use of spoiler vs callout
+
+You may notice that many of the older lessons use callouts for both additional material
+and to highlight imporant points interchangably.  Spoilers were developed in 2023
+to help with separating these two different use cases.
+
+:::::::::::::
+
+::::::::::::::::::
+
 :::::::::::::::::::::::::::::::::::::  discussion
 
 ## Lesson Time Management (10 minutes)

--- a/episodes/explanation.md
+++ b/episodes/explanation.md
@@ -131,7 +131,7 @@ content. You may consider making a [concept map][mental-map-instructor-training]
 Alternatively, if you decide to keep certain objectives in the lesson, you can add
 suggestions on which objectives can be skipped to the Instructor Notes for the lesson.
 
-:::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::: spoiler
 
 The Instructor Notes for the whole lesson should be added to the `instructors/instructor-notes.md` file.
 This page is displayed in the header menu when in "Instructor View".

--- a/episodes/formative-assessment.md
+++ b/episodes/formative-assessment.md
@@ -40,7 +40,7 @@ what learners learn from following your lesson
 matches its defined objectives as closely as possible. 
 To do so, you need to develop assessments to monitor progression towards your learning outcomes.
 
-::::::::::::::::::::::::::::::::::::::  callout
+::::::::::::::::::::::::::::::::::::::  spoiler
 
 ## Useful reading
 
@@ -124,7 +124,7 @@ higher-level cognitive skills may be better assessed by debugging tasks, [code-a
 or use-in-a-different-context exercises.
 
 
-::: callout
+::: spoiler
 
 ### Resources to Explore for More Example Assessment Types
 
@@ -204,7 +204,7 @@ Share the major points of your discussion in the collaborative notes document.
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
-::::::::::::::::::::::::::::::::::::::::: callout
+::::::::::::::::::::::::::::::::::::::::: spoiler
 
 ### Recommended Reading
 
@@ -253,7 +253,7 @@ Create LOs for the specific audience and create assessments for specific LOs."*
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
-::::::::::::::::::::::::::::::::::::::::: callout
+::::::::::::::::::::::::::::::::::::::::: spoiler
 
 ### Identifying Misconceptions
 Detecting and correcting 
@@ -295,7 +295,7 @@ spend the remainder reviewing and providing feedback on one another's assessment
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::::::::::::::: spoiler
 
 ## Assessing Knowledge Before a Workshop
 

--- a/episodes/infrastructure.md
+++ b/episodes/infrastructure.md
@@ -54,7 +54,7 @@ a toolkit that converts Markdown and RMarkdown files into the HTML
 that can be served by GitHub Pages.
 We will use it now to initialise a new lesson.
 
-::: callout
+::: spoiler
 
 ### A Brief History of The Carpentries Lesson Infrastructure
 
@@ -189,7 +189,7 @@ You may copy the URL in this box, this will be the address of your lesson site.
 
 ::::::::::::::::::::::::
 
-::: callout
+::: spoiler
 
 ### Which Branch and GitHub Actions
 
@@ -317,7 +317,7 @@ one of the components of The Carpentries Workbench,
 and should be left untouched.
 The page content begins after the blank line that follows this header.
 
-:::::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::::: spoiler
 
 ### Markdown Rendering on GitHub
 

--- a/episodes/narrative.md
+++ b/episodes/narrative.md
@@ -58,7 +58,7 @@ This can help you maintain a narrative flow and make the lesson feel more authen
 Even if your topic doesn't require a dataset, deciding on a consistent narrative will
 help create a flow between episodes and reduce cognitive load for learners.
 
-:::::::::::::::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::::::::::::::: spoiler
 
 ## Varying Examples
 
@@ -149,7 +149,7 @@ Lessons included in [The Carpentries Incubator][carpentries-incubator] are encou
 Even with a CC0 license, you will still want to follow best practice in
 giving attribution to the data provider or collecting agency.
 
-:::::::::::::::: callout
+:::::::::::::::: spoiler
 
 ## More CC0 License Reading
 

--- a/episodes/operations.md
+++ b/episodes/operations.md
@@ -52,7 +52,8 @@ as a value for the `life_cycle` field.
 For new lesson repositories, this value is already set to 'pre-alpha',
 so you should not have to change it yet.
 
-::: callout
+::: spoiler
+
 ### The `carpentry` Field
 
 The `config.yaml` file also contains a `carpentry` field, which can be used to adjust

--- a/episodes/preparing.md
+++ b/episodes/preparing.md
@@ -122,7 +122,7 @@ Another standard piece of The Carpentries Workbench are the *Instructor Notes* p
 
 It may initially be difficult to create Instructor Notes until you have taught the lesson yourself for the first time - but after the first pilot you will have enough feedback to draft them.
 
-::::::::::::::::::::::::::::::::::::::  callout
+::::::::::::::::::::::::::::::::::::::  spoiler
 
 ## Hidden Curriculum
 

--- a/episodes/project-management.md
+++ b/episodes/project-management.md
@@ -51,7 +51,7 @@ and are more suitable for project management tasks that are more continuous and 
 While a Milestone is associated with a single repository, 
 a Project can span over multiple Milestones and even different repositories within an organisation in GitHub. 
 
-::: callout
+::: spoiler
 
 ## Milestones vs Projects
 For a good description of differences between the two, have a look at [this answer on StackOverflow](https://stackoverflow.com/questions/39591795/what-is-the-difference-relationship-between-github-projects-and-milestones).

--- a/episodes/reflecting.md
+++ b/episodes/reflecting.md
@@ -112,7 +112,7 @@ Moving forward from your first pilot, the next steps to consider are:
   - do you need to re-organise and move some content around to improve the flow and narrative?
   - are there enough exercises and practical work?
   - do you need to realign your lesson objectives and key messages?
-- Decide if for some of the feedback you will not take action. Remember, you do not need to respond to every piece of feedback you receive. For example, it is easy to fall down the rabbit hole of adding extra material just because someone suggested it may be a useful thing - sometimes, adding a link or a callout to extra reading is sufficient. You need to be able to draw a line under any extra modification suggestions to keep you in scope and on schedule.
+- Decide if for some of the feedback you will not take action. Remember, you do not need to respond to every piece of feedback you receive. For example, it is easy to fall down the rabbit hole of adding extra material just because someone suggested it may be a useful thing - sometimes, adding a link or a spoiler pointing to extra reading is sufficient. You need to be able to draw a line under any extra modification suggestions to keep you in scope and on schedule.
 - Schedule follow-up co-working sessions with your team to carry on working on fixing issues and adding new content to maintain the momentum.
 - Add/Update your lessons' Instructor Notes based on what you learned and to help other instructors who will teach your lesson in the future.
 - Think about the timeline for your next pilot(s), even provisionally, to help you set milestones and targets to work towards.


### PR DESCRIPTION
This PR..
- updates the language in the callout about callouts to be a spoiler about spoilers
- makes many of the callouts into spoilers to indicate optional (spoiler) to teach vs vital (callout) to teach.

We might still need to find some place to talk about callouts.

Also recommend reviewing the rendered version of this PR since it will help you see where I kept the callouts vs switched them to spoilers.