### PR TITLE
Move computeBloom linkref

### DIFF
--- a/episodes/objectives.md
+++ b/episodes/objectives.md
@@ -368,4 +368,4 @@ and manage their expectations about what they will learn if they attend.
 
 [^1]: [Chatterjee & Corral (2017)](learners/reference.md#litref)
 [^2]: [Lujan & DiCarlo (2005)](learners/reference.md#litref)
-[computeBloom]: https://ccecc.acm.org/assessment/blooms-for-computing
+

--- a/links.md
+++ b/links.md
@@ -7,6 +7,7 @@
 [coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
 [codimd-notes-template]: https://codimd.carpentries.org/cldt-notes-template?both#Exercise-evaluating-learning-objectives-15-minutes
 [component-guide]: https://carpentries.github.io/sandpaper-docs/component-guide.html
+[computeBloom]: https://ccecc.acm.org/assessment/blooms-for-computing
 [curriculum-advisors]: https://carpentries.org/curriculum-advisors/
 [dc]: https://datacarpentry.org/
 [design-notes-template]: https://codimd.carpentries.org/HPwUE3FnTeSQJ9-_5EfU7Q?view#


### PR DESCRIPTION
I think the positioning of this linkref, underneath some footnote references, was confusing things. Hopefully this will fix it.