### PR TITLE
Unpin varnish version from my fork

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,5 +90,4 @@ instructors:
 # Learner Profiles
 profiles:
 
-# Enabling Matomo tracking for testing purposes
-varnish: tobyhodges/varnish@test-self-hosted-matomo
+analytics: carpentries


### PR DESCRIPTION
Matomo tracking was enabled in the core of varnish now, so we do not need this specific config any longer. Replacing with the general `analytics: carpentries` tracking config instead.