### PR TITLE
Update links to Code of Conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       value: >
         Thank you for taking time to tell us about a problem in this repository.
-        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/policies/coc/)
         Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
         If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 
         please contact The Carpentries Team at team@carpentries.org.

--- a/.github/ISSUE_TEMPLATE/suggest_improvement_1_lesson.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_improvement_1_lesson.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       value: >
         Thank you for taking time to suggest an improvement to this repository.
-        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/policies/coc/).
         
         Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
         If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 

--- a/.github/ISSUE_TEMPLATE/suggest_improvement_2_episode.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_improvement_2_episode.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       value: >
         Thank you for taking time to suggest an improvement to this repository.
-        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+        Before you submit the issue, please make sure you have read [The Carpentries Code of Conduct](https://docs.carpentries.org/policies/coc/)
         
         Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. 
         If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ _If any relevant discussions have taken place elsewhere, please provide links to
 
 <details>
 
-For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/policies/coc/).
 
 Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,9 +2,9 @@
 title: "Contributor Code of Conduct"
 ---
 As contributors and maintainers of this project,
-we pledge to follow the [Carpentry Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+we pledge to follow the [Carpentry Code of Conduct](https://docs.carpentries.org/policies/coc/).
 
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by following our [reporting guidelines][coc-reporting].
 
-[coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
+[coc-reporting]: https://docs.carpentries.org/policies/coc/incident-reporting.html

--- a/links.md
+++ b/links.md
@@ -4,7 +4,7 @@
 [carpentries-lab]: https://carpentries-lab.org/
 [carpentries-website]: https://carpentries.org/
 [cldt-site]: https://carpentries.github.io/lesson-development-training/
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc]: https://docs.carpentries.org/policies/coc/
 [codimd-notes-template]: https://codimd.carpentries.org/cldt-notes-template?both#Exercise-evaluating-learning-objectives-15-minutes
 [component-guide]: https://carpentries.github.io/sandpaper-docs/component-guide.html
 [computeBloom]: https://ccecc.acm.org/assessment/blooms-for-computing


### PR DESCRIPTION
The URL of The Carpentries Code of Conduct has changed since the launch of the revamped community handbook. This PR updates all of our links to point to the right page.

I am going to unilaterally merge this one, to bring us up to date ASAP.