### PR TITLE
Link to lesson developer handbook

### DIFF
--- a/episodes/lesson-design.md
+++ b/episodes/lesson-design.md
@@ -143,6 +143,8 @@ Although your lessons will probably remain in pre-alpha throughout this training
 some of the content will be equally valuable at later stages 
 and we will also point you towards resources to help with testing the lesson and gathering feedback.
 
+[The Carpentries Community Handbook](https://docs.carpentries.org/) provides [more information about the lesson life cycle](https://docs.carpentries.org/resources/curriculum/lesson-life-cycle).
+
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - We will learn to develop lessons based on the (slightly adapted) Nicholls' backward lesson design  process.

--- a/episodes/operations.md
+++ b/episodes/operations.md
@@ -181,6 +181,9 @@ and join/subscribe to any communication channels that you find interesting.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+## Further Reading
+[The Carpentries Lesson Developer Handbook](https://docs.carpentries.org/handbooks/lesson_developers) provides guidance and a list of resources for lesson developers to consult as they move through the different stages of development. 
+
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/wrap-up2.md
+++ b/episodes/wrap-up2.md
@@ -95,6 +95,8 @@ will change as you move through these stages.
 | beta             | feedback from pilot workshops; polishing changes; expanding instructor notes; suggestions for major overhauls/reorganisations | recruiting pilot instructors; reviewing changes; guiding contributors |
 | stable           | feedback from workshops; polishing changes; new/updated content | reviewing changes; guiding contributors; onboarding new maintainers; stepping away from the project |
 
+As you continue to make progress, remember that [The Carpentries Lesson Developer Handbook](https://docs.carpentries.org/handbooks/lesson_developers) provides guidance and a list of resources for lesson developers to consult.
+
 ## Farewell and Feedback
 
 Thank you for following this training.


### PR DESCRIPTION
[The Lesson Developer Handbook](https://docs.carpentries.org/handbooks/lesson_developers) has been launched, and this PR adds links in relevant places.