### PR TITLE
Update LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -74,10 +74,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ## Trademark
 
 "The Carpentries", "Software Carpentry" and "Data Carpentry" and their respective logos are
-registered trademarks of [Community Initiatives][CI].
+registered trademarks of [The Carpentries Inc][the-carpentries].
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [ci]: http://communityin.org/
 [osi]: https://opensource.org
+[the-carpentries]: https://carpentries.org/


### PR DESCRIPTION
Updates the description of trademark ownership in the license file, since The Carpentries is no longer fiscally-sponsored.