### PR TITLE
Slightly better anchor for Workbench setup instructions

### DIFF
--- a/episodes/lesson-content.md
+++ b/episodes/lesson-content.md
@@ -471,7 +471,7 @@ find and fix the problem when you notice the build process fail.
   and try to **build a version of the website on your local computer**,
   where the build process will be much faster.
   The Workbench documentation provides
-  [instructions for installing the infrastructure](https://carpentries.github.io/sandpaper-docs/#installation)
+  [instructions for installing the infrastructure](https://carpentries.github.io/sandpaper-docs/#setup)
   and [building a local preview of the lesson website](https://carpentries.github.io/sandpaper-docs/introduction.html#preview).
 
 


### PR DESCRIPTION
We noticed today that the link currently takes people straight to the Windows install instructions, so this change points to a heading a little further up the page.