### PR TITLE
link to setup instructions for maintenance workflows

### DIFF
--- a/episodes/lesson-content.md
+++ b/episodes/lesson-content.md
@@ -476,7 +476,7 @@ find and fix the problem when you notice the build process fail.
 
 ### Keeping your infrastructure up to date
 New versions of the workflows that build your lesson site will be released occasionally, and the Workbench includes a maintenance workflow that can help you keep your infrastructre healthy. 
-If you are using R Markdown source files in your lesson, you will also need to update the package dependencies of your lesson up to date and the Workbench provides a second maintenance workflow that can take care of that for you too.
+If you are using R Markdown source files in your lesson, you will also need to update the package dependencies of your lesson and the Workbench provides a second maintenance workflow that can take care of that for you too.
 Both of these maintenance workflows will open pull requests on your lesson repository, which you will need to merge for the updates to be applied.
 If your lesson is hosted in The Carpentries Incubator, these workflows will be configured for you.
 If you are keeping your lesson repository somewhere else instead (e.g. with your personal GitHub account or an organisation of your own), you will need to take care of [a few configuration steps to allow these maintenance workflows to open pull requests on the project on your behalf](https://docs.carpentries.org/resources/curriculum/lesson-forks.html#configure-maintenance-workflows).

--- a/episodes/lesson-content.md
+++ b/episodes/lesson-content.md
@@ -474,6 +474,12 @@ find and fix the problem when you notice the build process fail.
   [instructions for installing the infrastructure](https://carpentries.github.io/sandpaper-docs/#installation)
   and [building a local preview of the lesson website](https://carpentries.github.io/sandpaper-docs/introduction.html#preview).
 
+### Keeping your infrastructure up to date
+New versions of the workflows that build your lesson site will be released occasionally, and the Workbench includes a maintenance workflow that can help you keep your infrastructre healthy. 
+If you are using R Markdown source files in your lesson, you will also need to update the package dependencies of your lesson up to date and the Workbench provides a second maintenance workflow that can take care of that for you too.
+Both of these maintenance workflows will open pull requests on your lesson repository, which you will need to merge for the updates to be applied.
+If your lesson is hosted in The Carpentries Incubator, these workflows will be configured for you.
+If you are keeping your lesson repository somewhere else instead (e.g. with your personal GitHub account or an organisation of your own), you will need to take care of [a few configuration steps to allow these maintenance workflows to open pull requests on the project on your behalf](https://docs.carpentries.org/resources/curriculum/lesson-forks.html#configure-maintenance-workflows).
 
 [sandpaper-docs-learners]: https://carpentries.github.io/sandpaper-docs/editing.html#learners
 


### PR DESCRIPTION
Added some information about the workflow/package cache maintenance workflows, with a link to the instructions that people can follow to configure them for their repository.