### PR TITLE
Add link to Bloom's taxomony diagram

### DIFF
--- a/episodes/objectives.md
+++ b/episodes/objectives.md
@@ -141,6 +141,12 @@ which has since been disputed.
 Regardless of whether these skills conform to such a hierarchy,
 Bloom's Taxonomy serves as a very useful bank of action verbs for use
 in learning objectives.
+
+![Bloom's taxonomy - a framework for categorising educational goals](https://upload.wikimedia.org/wikipedia/commons/6/6a/Bloom%27s_revised_taxonomy.svg){
+alt="Bloom's taxonomy - a framework for categorising educational goals - represented as a pyramid with six levels of increasing cognitive complexity from the bottom to the top: remembering, understanging, applying, analysing, evaluating and creating"
+width="67%"
+}
+
 The Committee for Computing Education in Community Colleges has also created a [version of Bloom's Taxonomy customized for computing related training][computeBloom].
 
 We will see how helpful it can be to use action verbs in learning objectives


### PR DESCRIPTION
Add the correct link to Bloom's taxomony diagram after vanderbuilt one got broken. Fixes #488.