### PR TITLE
Link to webarchive of Alex Hill's blog post

### DIFF
--- a/episodes/collaborating-team.md
+++ b/episodes/collaborating-team.md
@@ -231,7 +231,7 @@ Making effective review comments in a PR is something you will get better at wit
 
 The Turing Way has more on [reviewing contributions](https://the-turing-way.netlify.app/collaboration/maintain-review/maintain-review-review),
 and a lot of the advice in Alex Hill's blog post,
-[_The Art of Giving and Receiving Code Reviews (Gracefully)_](https://web.archive.org/web/20240715171351/https://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/)
+[_The Art of Giving and Receiving Code Reviews (Gracefully)_](https://web.archive.org/web/20240715171351/https://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/) - [Video Recording](https://www.youtube.com/watch?v=XY6eA2_2hOg)
 also applies to reviewing prose.
 
 ::::::::::::::::


### PR DESCRIPTION
The link was broken to Alex Hill's blog post about giving better code reviews. Her website has a new URL and I couldn't find the post in the archive at the new address. This link uses the Wayback Machine to provide an archived version of the original post. If we prefer, we could instead link to [this YouTube video](https://www.youtube.com/watch?v=XY6eA2_2hOg) of a talk she gave on the same subject.