### PR TITLE
Add training calendar page

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,6 +22,14 @@ so the activities and examples used in this training are best suited to groups
 of trainees who want to collaborate on a lesson project.
 Efforts have been made to also cater to lesson developers working alone.
 
+:::::::::::::::::::::::::::::::: callout
+
+### Interested in Participating in this Training?
+Explore [the information page on The Carpentries website](https://carpentries.org/lesson-development/#collaborative-lesson-development-training) to learn more about the training.
+Visit [the Training Calendar](./learners/training-calendar.md) for a list of upcoming training events.
+
+::::::::::::::::::::::::::::::::::::::::
+
 
 ## Learning Objectives
 

--- a/learners/training-calendar.md
+++ b/learners/training-calendar.md
@@ -1,0 +1,76 @@
+---
+title: Training Calendar
+---
+
+## About Collaborative Lesson Developer Training
+
+This training teaches essential skills and good practices for designing and developing a lesson as an open source project. 
+The training will guide you through the design process and initial development of a new lesson, prepare you to work with the infrastructure we use to build accessible, open-source lesson websites, and provide some advice and techniques for effective collaboration on the project.
+
+For more information about what will be covered at this training, check out the rest of this [Collaborative Lesson Development Training Curriculum](https://carpentries.github.io/lesson-development-training/).
+
+In addition to participation in Collaborative Lesson Development Training, certification as a Carpentries Lesson Developer includes a ‘checkout' process. For more details, see our [Checkout Instructions page](https://carpentries.github.io/lesson-development-training/checkout.html).
+
+
+## How to Register for Collaborative Lesson Development Training
+For details of the pricing for Collaborative Lesson Development Training and the requirements for participation, check out [the information page on The Carpentries website](https://carpentries.org/lesson-development/).
+
+Those interested in participating in the training can register for events listed below by [contacting The Carpentries Curriculum Team](mailto:curriculum@carpentries.org).
+If you received a registration code from The Carpentries, e.g. via an organisational partnership agreement, please quote that in your message to the team.
+
+
+## When to Register
+
+### Partners and other groups
+
+Registration codes provided to partner organisations and other groups are active immediately and may be used for any event until one week prior to its start date.
+
+## Cancellation Policies
+
+If they need to cancel their participation, registered participants may [inform the Curriculum Team by email](mailto:curriculum@carpentries.org) before the start of the event. 
+To support our program and honour the time donated by our Lesson Developer Trainers, we ask that cancellations be made as far in advance as possible to allow other trainees to register before the 1 week deadline.
+
+After a registration has been cancelled, any registration code that was used to register will become available to sign up for a different event.
+
+If a trainee repeatedly registers and cancels (>3 times), or registers for more than one seat at the same time, they may be barred from further registration.
+
+### Attendance
+
+Trainees who miss more than 1 hour of an Collaborative Lesson Development Training event may be marked absent. 
+Lesson Developer certification cannot be completed without full attendance and participation at a training event.
+
+Follow the link from the date/time listed for each event to see the start time converted to your local time zone. 
+Please be sure to verify your availability for the full instructional time of your event. 
+If you expect to miss more than a total of 1 hour, please select a different event.
+
+## Upcoming Collaborative Lesson Development Training Events
+
+Registration closes one week prior to the training event. 
+New trainings are added to this calendar on a quarterly basis (generally in mid March, June, September, and December).
+
+---
+
+### [21-24 April 2026](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Collaborative+Lesson+Development+Training&iso=20260421T12&p1=%3A&ah=4)
+**Four 4-hour days:** 12:00 - 16:00 UTC | 14:00 - 18:00 Central European Summer Time | 08:00 - 12:00 Eastern Daylight Time.
+Follow the link above to see your local start time.
+
+---
+
+### [26-29 May 2026](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Collaborative+Lesson+Development+Training&iso=20260526T12&p1=%3A&ah=4)
+**Four 4-hour days:** 12:00 - 16:00 UTC | 14:00 - 18:00 Central European Summer Time | 08:00 - 12:00 Eastern Daylight Time.
+Follow the link above to see your local start time.
+
+---
+
+### [22-25 June 2026](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Collaborative+Lesson+Development+Training&iso=20260622T16&p1=%3A&ah=4)
+**Four 4-hour days:** 16:00 - 20:00 UTC | 12:00 - 16:00 Eastern Daylight Time | 09:00 - 13:00 Pacific Daylight Time.
+Follow the link above to see your local start time.
+
+
+## Accessibility Support
+
+We do not require participants to provide documentation of disabilities or disclose any unnecessary personal information. 
+However, we do want to help create an inclusive, accessible experience for all participants. 
+We encourage you to share any information that would be helpful to make your Carpentries experience accessible. 
+To request accessibility support (also known as accommodations) for this training, please fill out the [accessibility support request form](https://carpentries.typeform.com/to/B2OSYaD0)
+If you have questions or need assistance with the accessibility support form please [email us](mailto:curriculum@carpentries.org).


### PR DESCRIPTION
It looks like we need to wait a bit longer to get CLDT registration setup in pretix. When that is ready it will provide a list of upcoming events and a way for people to register for them witha  registration code (similar to how registration is handled for Instructor Training). 

As a stopgap for the time-being, this PR adds a Training Calendar page similar to [the one for Instructor Training](https://carpentries.github.io/instructor-training/training_calendar.html), listing upcoming events and providing some basic info about the training and how to join it. As I understand it, that additional info is primarily there for folks who find their way to the training curriculum and want to learn more about how to participate in the program.

The page will be removed again when we have events listed and registrations handled in pretix.

