### PR TITLE
Fix broken link to training calendar

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ Efforts have been made to also cater to lesson developers working alone.
 
 ### Interested in Participating in this Training?
 Explore [the information page on The Carpentries website](https://carpentries.org/lesson-development/#collaborative-lesson-development-training) to learn more about the training.
-Visit [the Training Calendar](./learners/training-calendar.md) for a list of upcoming training events.
+Visit [the Training Calendar](learners/training-calendar.md) for a list of upcoming training events.
 
 ::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
This PR updates the relative link to the training calendar so that it is correctly resolved and does not result in a `page not found` error on the github pages website. I verified the issue and fix by building the site locally before and after the change and checking behaviour.

This PR resolves #562 and addresses a different issue than the issue addressed in PR #560.